### PR TITLE
fix: Spaces back link navigates to Dynatrace chooser

### DIFF
--- a/src/pages/projects/dynatrace/spaces.astro
+++ b/src/pages/projects/dynatrace/spaces.astro
@@ -793,7 +793,7 @@ html {
 <body>
 
 <nav class="nav">
-  <a href="/" class="nav-link">&larr; Back to Work</a>
+  <a href="/projects/dynatrace" class="nav-link">&larr; Back to Dynatrace</a>
   <div>
     <span class="nav-link">Dynatrace / 2025&ndash;2026</span>
   </div>


### PR DESCRIPTION
## Summary
- Spaces case study "Back" link now goes to `/projects/dynatrace` (chooser page) instead of `/` (homepage)

## Test plan
- [ ] From Spaces case study, click "Back to Dynatrace" → lands on chooser page

🤖 Generated with [Claude Code](https://claude.com/claude-code)