### PR TITLE
Add Dynatrace chooser page and prototype CTAs

### DIFF
--- a/src/pages/projects/dynatrace/settings-platform.astro
+++ b/src/pages/projects/dynatrace/settings-platform.astro
@@ -545,6 +545,20 @@ html { scroll-behavior: smooth; }
     </div>
   </section>
 
+  <!-- PROTOTYPE CTA -->
+  <section class="section" style="padding-bottom: 0;">
+    <div style="background: linear-gradient(135deg, rgba(99,102,241,0.08), rgba(20,150,255,0.08)); border: 1px solid rgba(99,102,241,0.2); border-radius: 16px; padding: 40px 48px; display: flex; align-items: center; justify-content: space-between; gap: 32px; flex-wrap: wrap;">
+      <div style="flex: 1; min-width: 280px;">
+        <span class="section-label" style="margin-bottom: 8px;">Interactive Prototype</span>
+        <h3 style="font-size: 22px; font-weight: 600; color: #ffffff; margin-top: 8px; margin-bottom: 8px;">Explore the Settings Prototype</h3>
+        <p style="font-size: 15px; color: rgba(255,255,255,0.6); line-height: 1.6; max-width: 520px;">Navigate the control tower landing page, category views, schema details, and overrides hub I designed and coded as a React prototype.</p>
+      </div>
+      <a href="https://spaces-prototype.netlify.app/settings" target="_blank" rel="noopener noreferrer" style="display: inline-flex; align-items: center; gap: 8px; padding: 14px 28px; background: rgba(99,102,241,0.9); color: #ffffff; font-size: 15px; font-weight: 600; border-radius: 10px; text-decoration: none; white-space: nowrap; transition: background 0.2s ease;">
+        View Prototype &rarr;
+      </a>
+    </div>
+  </section>
+
   <!-- 08 — REFLECTION -->
   <section class="section">
     <div class="section-header">

--- a/src/pages/projects/dynatrace/spaces.astro
+++ b/src/pages/projects/dynatrace/spaces.astro
@@ -1242,6 +1242,20 @@ html {
     </div>
   </div>
 
+  <!-- PROTOTYPE CTA -->
+  <section class="section" style="padding-bottom: 0;">
+    <div style="background: linear-gradient(135deg, rgba(99,102,241,0.08), rgba(20,150,255,0.08)); border: 1px solid rgba(99,102,241,0.2); border-radius: 16px; padding: 40px 48px; display: flex; align-items: center; justify-content: space-between; gap: 32px; flex-wrap: wrap;">
+      <div style="flex: 1; min-width: 280px;">
+        <span class="section-label" style="margin-bottom: 8px;">Interactive Prototype</span>
+        <h3 style="font-size: 22px; font-weight: 600; color: #ffffff; margin-top: 8px; margin-bottom: 8px;">Explore the Spaces Prototype</h3>
+        <p style="font-size: 15px; color: rgba(255,255,255,0.6); line-height: 1.6; max-width: 520px;">Walk through the persona-based navigation, Space creation wizard, and settings views I designed and coded as a React prototype.</p>
+      </div>
+      <a href="https://spaces-prototype.netlify.app/" target="_blank" rel="noopener noreferrer" style="display: inline-flex; align-items: center; gap: 8px; padding: 14px 28px; background: rgba(99,102,241,0.9); color: #ffffff; font-size: 15px; font-weight: 600; border-radius: 10px; text-decoration: none; white-space: nowrap; transition: background 0.2s ease;">
+        View Prototype &rarr;
+      </a>
+    </div>
+  </section>
+
   <!-- 07 — REFLECTION -->
   <section class="section">
     <div class="section-header">


### PR DESCRIPTION
## Summary
- Adds a Dynatrace project chooser page at `/projects/dynatrace/` with cards linking to Spaces and Settings Platform case studies
- Wires interactive prototype CTAs into both case studies, linking to the newly deployed [spaces-prototype.netlify.app](https://spaces-prototype.netlify.app/)
- Fixes navigation (back links, clickable cards, edge function routing)

## Test plan
- [ ] Visit `/projects/dynatrace` — chooser page renders with both project cards
- [ ] Click through to each case study — back links return to chooser
- [ ] Verify "View Prototype" CTA appears before the reflection section in both case studies
- [ ] Confirm prototype links open in new tab and load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)