### PR TITLE
feat: add notes system with RSS, tags, and reading time

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -10,6 +10,7 @@ import tailwindcss from '@tailwindcss/vite';
 
 // https://astro.build/config
 export default defineConfig({
+  site: 'https://nilsongaspar.com',
   integrations: [
     react(),
     mdx({

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@astrojs/mdx": "^4.3.4",
         "@astrojs/react": "^4.3.1",
+        "@astrojs/rss": "^4.0.18",
         "@tailwindcss/vite": "^4.1.12",
         "@types/react": "^19.1.13",
         "@types/react-dom": "^19.1.9",
@@ -17,6 +18,7 @@
         "framer-motion": "^12.23.13",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
+        "reading-time": "^1.5.0",
         "rehype-raw": "^7.0.0",
         "remark-directive": "^4.0.0",
         "tailwindcss": "^4.1.12",
@@ -204,6 +206,26 @@
         "@types/react-dom": "^17.0.17 || ^18.0.6 || ^19.0.0",
         "react": "^17.0.2 || ^18.0.0 || ^19.0.0",
         "react-dom": "^17.0.2 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@astrojs/rss": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@astrojs/rss/-/rss-4.0.18.tgz",
+      "integrity": "sha512-wc5DwKlbTEdgVAWnHy8krFTeQ42t1v/DJqeq5HtulYK3FYHE4krtRGjoyhS3eXXgfdV6Raoz2RU3wrMTFAitRg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-parser": "^5.5.7",
+        "piccolore": "^0.1.3",
+        "zod": "^4.3.6"
+      }
+    },
+    "node_modules/@astrojs/rss/node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@astrojs/telemetry": {
@@ -1783,6 +1805,18 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -5424,6 +5458,44 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/fast-xml-builder": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.8.0.tgz",
+      "integrity": "sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.2.0",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.3.0",
+        "xml-naming": "^0.1.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/fastq": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
@@ -8786,6 +8858,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -8812,6 +8899,12 @@
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/piccolore": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/piccolore/-/piccolore-0.1.3.tgz",
+      "integrity": "sha512-o8bTeDWjE086iwKrROaDf31K0qC/BENdm15/uH9usSC/uZjJOKb2YGiVHfLY4GhwsERiPI1jmwI2XrA7ACOxVw==",
+      "license": "ISC"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -9286,6 +9379,12 @@
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
       }
+    },
+    "node_modules/reading-time": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/reading-time/-/reading-time-1.5.0.tgz",
+      "integrity": "sha512-onYyVhBNr4CmAxFsKS7bz+uTLRakypIe4R+5A824vBSkQy/hB3fZepoVEf8OVAxzLvK+H/jm9TzpI3ETSm64Kg==",
+      "license": "MIT"
     },
     "node_modules/recma-build-jsx": {
       "version": "1.0.0",
@@ -10216,6 +10315,18 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/strnum": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/style-to-js": {
       "version": "1.1.17",
@@ -11418,6 +11529,21 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/xxhash-wasm": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@astrojs/mdx": "^4.3.4",
     "@astrojs/react": "^4.3.1",
+    "@astrojs/rss": "^4.0.18",
     "@tailwindcss/vite": "^4.1.12",
     "@types/react": "^19.1.13",
     "@types/react-dom": "^19.1.9",
@@ -30,6 +31,7 @@
     "framer-motion": "^12.23.13",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
+    "reading-time": "^1.5.0",
     "rehype-raw": "^7.0.0",
     "remark-directive": "^4.0.0",
     "tailwindcss": "^4.1.12",

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -16,6 +16,7 @@ const notes = defineCollection({
     title: z.string(),
     description: z.string(),
     publishDate: z.coerce.date(),
+    updatedDate: z.coerce.date().optional(),
     tags: z.array(z.string()).default([]),
     draft: z.boolean().default(false),
     featured: z.boolean().default(false),

--- a/src/content/notes/reality-and-fiction-in-figma.md
+++ b/src/content/notes/reality-and-fiction-in-figma.md
@@ -1,0 +1,31 @@
+---
+title: 'Reality and Fiction in Figma'
+description: 'The gap between using a tool and understanding what is underneath it — and why that matters more in the age of AI agents.'
+publishDate: 2026-05-20
+tags: ['design', 'ai', 'code']
+featured: true
+---
+
+I was in a session with one of my mentees. I started by priming the CodePen environment, removing the automated margin and padding with CSS. Then I showed them how to create a div, give it a specific width and height, attach a color so it would be visible. We moved the box around the canvas. And then I told them: this is the precursor to the Auto Layout you've been using in Figma all along.
+
+They were slightly surprised. They'd never really considered it, even after years of designing. Opening the browser console to investigate code wasn't an ingrained practice for them. They did it sometimes, but not as habit. With that newfound knowledge, they became more curious about where Figma's features had originated.
+
+Slowly they started to see that Figma itself is an app, and there are things they could do inside it that weren't grounded to its UI. The browser could do the same things, in code. That reshaped how they thought about layout. It stopped being something artistic, or something that followed the design system without question. It became: how can this fit on a different screen size?
+
+That gap, between using a tool and understanding what's underneath it, isn't only a Figma thing. It shows up again, more loudly, in how designers work with AI now.
+
+At my last company, leadership started pushing everyone to adopt AI in their day-to-day work. One thing designers began to struggle with, and become a little addicted to, was how easy it was to get an output from a prompt. But most of the time, that output was based on whatever libraries the AI agent had as reference: shadcn, Tailwind, DaisyUI. The agent applies those components to the output. Even with an MCP in the loop, it would often miss the mark.
+
+So the designer would be frustrated that the output wasn't a one-to-one copy of the original design, and they'd start treating the AI like a human. They'd get angry. They'd use bad words. And the agent has fail-safes. It's trained not to be confrontational, to be human-pleasing. So it would spiral. Retry, retry, retry, while the designer's frustration grew. Then they'd paste their poorly-written prompt into a second LLM, ask it to make the prompt clearer for the first agent, paste the new version back, and still not get the exact result.
+
+I've been here myself. At the end of 2023, I started heavily experimenting with AI in my design process. The token limits in those days were tight. There wasn't room for a casual conversation with the agent. I had to be intentional about every prompt. I was using v0 from Vercel and Lovable most, and what I remember most clearly is the frustration of an agent hitting its token limit and forgetting what we'd been talking about. My workaround was to copy the entire previous conversation into a markdown file and pass it to the next agent as memory.
+
+Over time I noticed it was more efficient to dig into the code and fix things directly than to spend tokens trying to make the agent understand exactly what I wanted. That's what shaped how I work with AI today.
+
+Most of what those frustrated designers were prompting the agent to fix could have been fixed in a code editor, live. Working with the agent. Not delegating to it and getting angry at the results.
+
+A recent example. I'd been prototyping an iteration with the AI agent and noticed that some page elements weren't aligned the way I wanted. I opened my code editor of choice, VSCodium, and jumped in live. I fixed the flex component that was making the layout weird, and while I was doing it I was telling the agent: this is how I want it.
+
+That became a benchmark, a way for the agent to learn how I usually want things to look. On the next iteration, it already knew how I wanted that specific layout to behave.
+
+Should designers learn code? Yes. Same way we learn color theory, visual hierarchy, layout. It's a fundamental, not a handoff skill. The old debate framed code literacy as a favor designers do for developers. What I've come to think instead: it's the favor we do for our own design thinking.

--- a/src/content/notes/reality-and-fiction-in-figma.md
+++ b/src/content/notes/reality-and-fiction-in-figma.md
@@ -1,6 +1,6 @@
 ---
 title: 'Reality and Fiction in Figma'
-description: 'The gap between using a tool and understanding what is underneath it — and why that matters more in the age of AI agents.'
+description: 'The gap between using a tool and understanding what is underneath it, and why that matters more in the age of AI agents.'
 publishDate: 2026-05-20
 tags: ['design', 'ai', 'code']
 featured: true

--- a/src/lib/notes.ts
+++ b/src/lib/notes.ts
@@ -1,0 +1,47 @@
+import { getCollection, type CollectionEntry } from 'astro:content';
+import readingTime from 'reading-time';
+
+export type Note = CollectionEntry<'notes'>;
+
+export async function getPublishedNotes(): Promise<Note[]> {
+  const notes = await getCollection('notes', ({ data }) => {
+    return import.meta.env.PROD ? data.draft !== true : true;
+  });
+  return notes.sort(
+    (a, b) => b.data.publishDate.valueOf() - a.data.publishDate.valueOf(),
+  );
+}
+
+export function groupByYear(notes: Note[]): Array<[number, Note[]]> {
+  const map = new Map<number, Note[]>();
+  for (const note of notes) {
+    const year = note.data.publishDate.getFullYear();
+    if (!map.has(year)) map.set(year, []);
+    map.get(year)!.push(note);
+  }
+  return Array.from(map.entries()).sort((a, b) => b[0] - a[0]);
+}
+
+export function getAllTags(notes: Note[]): string[] {
+  const tags = new Set<string>();
+  for (const note of notes) {
+    for (const tag of note.data.tags) tags.add(tag);
+  }
+  return Array.from(tags).sort();
+}
+
+export function getNoteStats(body: string): { minutes: number; words: number } {
+  const stats = readingTime(body);
+  return { minutes: Math.max(1, Math.ceil(stats.minutes)), words: stats.words };
+}
+
+export function formatDate(date: Date): string {
+  return date.toLocaleDateString('en-US', {
+    month: 'short',
+    day: '2-digit',
+  });
+}
+
+export function tagSlug(tag: string): string {
+  return tag.toLowerCase().replace(/\s+/g, '-');
+}

--- a/src/pages/notes/[...slug].astro
+++ b/src/pages/notes/[...slug].astro
@@ -1,9 +1,11 @@
 ---
 import { type CollectionEntry, getCollection } from 'astro:content';
-import BaseLayout from '../../layouts/BaseLayout.astro';
+import { getNoteStats, tagSlug } from '../../lib/notes';
 
 export async function getStaticPaths() {
-  const notes = await getCollection('notes');
+  const notes = await getCollection('notes', ({ data }) => {
+    return import.meta.env.PROD ? data.draft !== true : true;
+  });
   return notes.map((note) => ({
     params: { slug: note.slug },
     props: note,
@@ -14,42 +16,327 @@ type Props = CollectionEntry<'notes'>;
 
 const note = Astro.props;
 const { Content } = await note.render();
-const { title, description, publishDate, tags } = note.data;
+const { title, description, publishDate, updatedDate, tags } = note.data;
+const stats = getNoteStats(note.body);
+
+const formattedDate = publishDate.toLocaleDateString('en-US', {
+  year: 'numeric',
+  month: 'long',
+  day: 'numeric',
+});
+
+const formattedUpdated = updatedDate?.toLocaleDateString('en-US', {
+  year: 'numeric',
+  month: 'long',
+  day: 'numeric',
+});
 ---
 
-<BaseLayout title={title} description={description}>
-  <main class="mx-auto max-w-3xl px-4 py-8">
-    <article>
-      <header class="mb-8">
-        <h1 class="mb-4 text-4xl font-bold">{title}</h1>
-        <p class="mb-4 text-lg text-gray-400">{description}</p>
-        <div class="flex items-center gap-4 text-sm text-gray-500">
-          <time datetime={publishDate.toISOString()}>
-            {
-              publishDate.toLocaleDateString('en-US', {
-                year: 'numeric',
-                month: 'long',
-                day: 'numeric',
-              })
-            }
-          </time>
-          {
-            tags.length > 0 && (
-              <div class="flex gap-2">
-                {tags.map((tag) => (
-                  <span class="rounded bg-gray-800 px-2 py-1 text-xs">
-                    {tag}
-                  </span>
-                ))}
-              </div>
-            )
-          }
-        </div>
-      </header>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-      <div class="prose prose-invert prose-gray max-w-none">
-        <Content />
-      </div>
-    </article>
-  </main>
-</BaseLayout>
+<title>{title} — Nilson Gaspar</title>
+<meta name="description" content={description}>
+<meta name="author" content="Nilson Gaspar">
+
+<meta property="og:type" content="article">
+<meta property="og:title" content={title}>
+<meta property="og:description" content={description}>
+<meta property="article:published_time" content={publishDate.toISOString()}>
+{updatedDate && <meta property="article:modified_time" content={updatedDate.toISOString()} />}
+{tags.map((tag) => <meta property="article:tag" content={tag} />)}
+
+<link rel="alternate" type="application/rss+xml" title="Nilson Gaspar — Notes" href="/rss.xml">
+
+<link rel="icon" type="image/svg+xml" href="/favicon.svg">
+<link rel="icon" type="image/png" href="/favicon.png">
+
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+
+  :root {
+    --bg: #1a1a1a;
+    --text: #e8e8e8;
+    --muted: #888;
+    --dim: #555;
+    --rule: rgba(255, 255, 255, 0.08);
+    --accent: #fff;
+  }
+
+  body {
+    background: var(--bg);
+    color: var(--text);
+    font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+    font-size: 14px;
+    line-height: 1.6;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
+
+  .nav {
+    padding: 32px 48px;
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+  }
+
+  .nav a, .nav span {
+    color: var(--muted);
+    text-decoration: none;
+    font-size: 12px;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+  }
+
+  .nav a:hover { color: var(--text); }
+
+  .container {
+    max-width: 640px;
+    margin: 0 auto;
+    padding: 80px 48px 120px;
+  }
+
+  .article-header {
+    margin-bottom: 64px;
+    padding-bottom: 32px;
+    border-bottom: 1px solid var(--rule);
+  }
+
+  .article-eyebrow {
+    font-size: 12px;
+    color: var(--dim);
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    margin-bottom: 24px;
+  }
+
+  .article-title {
+    font-family: -apple-system, BlinkMacSystemFont, "SF Pro Display", "Inter", system-ui, sans-serif;
+    font-size: 32px;
+    font-weight: 600;
+    line-height: 1.2;
+    letter-spacing: -0.02em;
+    color: #fff;
+    margin-bottom: 16px;
+  }
+
+  .article-description {
+    font-family: -apple-system, BlinkMacSystemFont, "SF Pro Display", "Inter", system-ui, sans-serif;
+    font-size: 17px;
+    color: var(--muted);
+    line-height: 1.5;
+    margin-bottom: 24px;
+  }
+
+  .article-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 16px;
+    color: var(--dim);
+    font-size: 12px;
+    letter-spacing: 0.02em;
+  }
+
+  .article-meta .sep {
+    color: var(--dim);
+    opacity: 0.5;
+  }
+
+  .article-meta time {
+    color: var(--muted);
+  }
+
+  .article-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+  }
+
+  .article-tags a {
+    color: var(--dim);
+    text-decoration: none;
+    transition: color 0.15s;
+  }
+
+  .article-tags a:hover { color: var(--text); }
+
+  /* Prose styles — body is sans for readability */
+  .prose {
+    font-family: -apple-system, BlinkMacSystemFont, "SF Pro Display", "Inter", system-ui, sans-serif;
+    font-size: 17px;
+    line-height: 1.7;
+    color: var(--text);
+  }
+
+  .prose p {
+    margin-bottom: 1.5em;
+  }
+
+  .prose h2 {
+    font-size: 22px;
+    font-weight: 600;
+    color: #fff;
+    margin: 2.5em 0 0.75em;
+    letter-spacing: -0.01em;
+  }
+
+  .prose h3 {
+    font-size: 18px;
+    font-weight: 600;
+    color: #fff;
+    margin: 2em 0 0.5em;
+  }
+
+  .prose a {
+    color: var(--text);
+    text-decoration: underline;
+    text-decoration-color: var(--dim);
+    text-underline-offset: 3px;
+    transition: text-decoration-color 0.15s;
+  }
+
+  .prose a:hover {
+    text-decoration-color: var(--text);
+  }
+
+  .prose strong { color: #fff; font-weight: 600; }
+
+  .prose em { color: var(--text); font-style: italic; }
+
+  .prose blockquote {
+    border-left: 2px solid var(--dim);
+    padding-left: 20px;
+    margin: 2em 0;
+    color: var(--muted);
+    font-style: italic;
+  }
+
+  .prose ul, .prose ol {
+    margin: 1.5em 0;
+    padding-left: 1.5em;
+  }
+
+  .prose li {
+    margin-bottom: 0.5em;
+  }
+
+  .prose code {
+    font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+    background: rgba(255, 255, 255, 0.06);
+    padding: 2px 6px;
+    border-radius: 3px;
+    font-size: 0.9em;
+  }
+
+  .prose pre {
+    background: #0f0f0f;
+    border: 1px solid var(--rule);
+    padding: 20px;
+    border-radius: 4px;
+    overflow-x: auto;
+    margin: 1.5em 0;
+    font-size: 13px;
+    line-height: 1.5;
+  }
+
+  .prose pre code {
+    background: none;
+    padding: 0;
+    font-size: inherit;
+  }
+
+  .prose hr {
+    border: none;
+    border-top: 1px solid var(--rule);
+    margin: 3em 0;
+  }
+
+  .prose img {
+    max-width: 100%;
+    height: auto;
+    margin: 2em 0;
+    border-radius: 4px;
+  }
+
+  .footer {
+    margin-top: 96px;
+    padding-top: 32px;
+    border-top: 1px solid var(--rule);
+    display: flex;
+    justify-content: space-between;
+    color: var(--muted);
+    font-size: 12px;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+  }
+
+  .footer a {
+    color: var(--muted);
+    text-decoration: none;
+  }
+
+  .footer a:hover { color: var(--text); }
+
+  .updated-note {
+    margin-top: 8px;
+    color: var(--dim);
+    font-size: 12px;
+  }
+
+  ::selection { background: #444; color: #fff; }
+
+  @media (max-width: 640px) {
+    .container { padding: 48px 24px 80px; }
+    .article-title { font-size: 26px; }
+    .article-description { font-size: 16px; }
+    .prose { font-size: 16px; }
+  }
+</style>
+</head>
+<body>
+
+<nav class="nav">
+  <a href="/notes">&larr; Notes</a>
+  <a href="/rss.xml">RSS</a>
+</nav>
+
+<div class="container">
+  <header class="article-header">
+    <div class="article-eyebrow">Note</div>
+    <h1 class="article-title">{title}</h1>
+    <p class="article-description">{description}</p>
+    <div class="article-meta">
+      <time datetime={publishDate.toISOString()}>{formattedDate}</time>
+      <span class="sep">·</span>
+      <span>{stats.minutes} min read</span>
+      <span class="sep">·</span>
+      <span>{stats.words.toLocaleString()} words</span>
+      {tags.length > 0 && <span class="sep">·</span>}
+      {tags.length > 0 && (
+        <div class="article-tags">
+          {tags.map((tag) => (
+            <a href={`/notes/tag/${tagSlug(tag)}`}>#{tag}</a>
+          ))}
+        </div>
+      )}
+    </div>
+    {formattedUpdated && (
+      <div class="updated-note">Last updated {formattedUpdated}</div>
+    )}
+  </header>
+
+  <article class="prose">
+    <Content />
+  </article>
+
+  <footer class="footer">
+    <a href="/notes">&larr; All notes</a>
+    <a href="/">Home</a>
+  </footer>
+</div>
+
+</body>
+</html>

--- a/src/pages/notes/[...slug].astro
+++ b/src/pages/notes/[...slug].astro
@@ -38,7 +38,7 @@ const formattedUpdated = updatedDate?.toLocaleDateString('en-US', {
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<title>{title} — Nilson Gaspar</title>
+<title>{title} | Nilson Gaspar</title>
 <meta name="description" content={description}>
 <meta name="author" content="Nilson Gaspar">
 
@@ -49,7 +49,7 @@ const formattedUpdated = updatedDate?.toLocaleDateString('en-US', {
 {updatedDate && <meta property="article:modified_time" content={updatedDate.toISOString()} />}
 {tags.map((tag) => <meta property="article:tag" content={tag} />)}
 
-<link rel="alternate" type="application/rss+xml" title="Nilson Gaspar — Notes" href="/rss.xml">
+<link rel="alternate" type="application/rss+xml" title="Nilson Gaspar Notes" href="/rss.xml">
 
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="icon" type="image/png" href="/favicon.png">
@@ -58,12 +58,12 @@ const formattedUpdated = updatedDate?.toLocaleDateString('en-US', {
   * { margin: 0; padding: 0; box-sizing: border-box; }
 
   :root {
-    --bg: #1a1a1a;
-    --text: #e8e8e8;
-    --muted: #888;
-    --dim: #555;
+    --bg: #30302e;
+    --text: #ffffff;
+    --muted: #aaa;
+    --dim: #888;
+    --faint: #666;
     --rule: rgba(255, 255, 255, 0.08);
-    --accent: #fff;
   }
 
   body {
@@ -77,98 +77,133 @@ const formattedUpdated = updatedDate?.toLocaleDateString('en-US', {
   }
 
   .nav {
-    padding: 32px 48px;
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    padding: 24px 48px;
+    background: linear-gradient(to bottom, var(--bg) 0%, transparent 100%);
+    z-index: 100;
+    backdrop-filter: blur(10px);
     display: flex;
     justify-content: space-between;
     align-items: baseline;
   }
 
-  .nav a, .nav span {
-    color: var(--muted);
+  .nav a {
+    color: var(--dim);
     text-decoration: none;
-    font-size: 12px;
-    letter-spacing: 0.05em;
+    font-size: 13px;
+    letter-spacing: 0.08em;
     text-transform: uppercase;
+    transition: color 0.2s;
   }
 
   .nav a:hover { color: var(--text); }
 
-  .container {
-    max-width: 640px;
+  .wrap {
+    max-width: 1200px;
     margin: 0 auto;
-    padding: 80px 48px 120px;
+    padding: 140px 48px 120px;
   }
 
+  /* Header — spans full width above the two-column grid */
   .article-header {
-    margin-bottom: 64px;
-    padding-bottom: 32px;
+    max-width: 880px;
+    margin: 0 auto 80px;
+    padding-bottom: 48px;
     border-bottom: 1px solid var(--rule);
   }
 
   .article-eyebrow {
     font-size: 12px;
-    color: var(--dim);
-    letter-spacing: 0.1em;
+    color: var(--faint);
+    letter-spacing: 0.15em;
     text-transform: uppercase;
-    margin-bottom: 24px;
+    margin-bottom: 32px;
   }
 
   .article-title {
     font-family: -apple-system, BlinkMacSystemFont, "SF Pro Display", "Inter", system-ui, sans-serif;
-    font-size: 32px;
+    font-size: clamp(36px, 5vw, 56px);
     font-weight: 600;
-    line-height: 1.2;
-    letter-spacing: -0.02em;
+    line-height: 1.05;
+    letter-spacing: -0.025em;
     color: #fff;
-    margin-bottom: 16px;
+    margin-bottom: 24px;
   }
 
   .article-description {
     font-family: -apple-system, BlinkMacSystemFont, "SF Pro Display", "Inter", system-ui, sans-serif;
-    font-size: 17px;
+    font-size: 20px;
+    font-weight: 300;
     color: var(--muted);
     line-height: 1.5;
-    margin-bottom: 24px;
+    max-width: 700px;
   }
 
-  .article-meta {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 16px;
-    color: var(--dim);
+  /* Body grid — meta rail on left, prose on right */
+  .article-body {
+    display: grid;
+    grid-template-columns: 200px 1fr;
+    gap: 80px;
+    max-width: 1080px;
+    margin: 0 auto;
+  }
+
+  .meta-rail {
+    position: sticky;
+    top: 120px;
+    align-self: start;
     font-size: 12px;
+    color: var(--dim);
     letter-spacing: 0.02em;
   }
 
-  .article-meta .sep {
-    color: var(--dim);
-    opacity: 0.5;
+  .meta-block {
+    margin-bottom: 32px;
   }
 
-  .article-meta time {
-    color: var(--muted);
+  .meta-label {
+    color: var(--faint);
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    margin-bottom: 8px;
+    font-size: 11px;
   }
 
-  .article-tags {
+  .meta-value {
+    color: var(--text);
+    font-size: 13px;
+  }
+
+  .meta-tags {
     display: flex;
-    flex-wrap: wrap;
-    gap: 12px;
+    flex-direction: column;
+    gap: 6px;
   }
 
-  .article-tags a {
-    color: var(--dim);
+  .meta-tags a {
+    color: var(--muted);
     text-decoration: none;
-    transition: color 0.15s;
+    font-size: 13px;
+    transition: color 0.2s;
   }
 
-  .article-tags a:hover { color: var(--text); }
+  .meta-tags a:hover { color: var(--text); }
 
-  /* Prose styles — body is sans for readability */
+  .updated-line {
+    color: var(--faint);
+    font-size: 12px;
+  }
+
+  /* Prose */
   .prose {
     font-family: -apple-system, BlinkMacSystemFont, "SF Pro Display", "Inter", system-ui, sans-serif;
-    font-size: 17px;
-    line-height: 1.7;
+    font-size: 18px;
+    line-height: 1.75;
     color: var(--text);
+    max-width: 720px;
   }
 
   .prose p {
@@ -176,15 +211,16 @@ const formattedUpdated = updatedDate?.toLocaleDateString('en-US', {
   }
 
   .prose h2 {
-    font-size: 22px;
+    font-size: 26px;
     font-weight: 600;
     color: #fff;
     margin: 2.5em 0 0.75em;
     letter-spacing: -0.01em;
+    line-height: 1.25;
   }
 
   .prose h3 {
-    font-size: 18px;
+    font-size: 20px;
     font-weight: 600;
     color: #fff;
     margin: 2em 0 0.5em;
@@ -194,21 +230,18 @@ const formattedUpdated = updatedDate?.toLocaleDateString('en-US', {
     color: var(--text);
     text-decoration: underline;
     text-decoration-color: var(--dim);
-    text-underline-offset: 3px;
-    transition: text-decoration-color 0.15s;
+    text-underline-offset: 4px;
+    transition: text-decoration-color 0.2s;
   }
 
-  .prose a:hover {
-    text-decoration-color: var(--text);
-  }
+  .prose a:hover { text-decoration-color: var(--text); }
 
   .prose strong { color: #fff; font-weight: 600; }
-
   .prose em { color: var(--text); font-style: italic; }
 
   .prose blockquote {
     border-left: 2px solid var(--dim);
-    padding-left: 20px;
+    padding-left: 24px;
     margin: 2em 0;
     color: var(--muted);
     font-style: italic;
@@ -219,27 +252,25 @@ const formattedUpdated = updatedDate?.toLocaleDateString('en-US', {
     padding-left: 1.5em;
   }
 
-  .prose li {
-    margin-bottom: 0.5em;
-  }
+  .prose li { margin-bottom: 0.5em; }
 
   .prose code {
     font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
-    background: rgba(255, 255, 255, 0.06);
+    background: rgba(255, 255, 255, 0.08);
     padding: 2px 6px;
     border-radius: 3px;
-    font-size: 0.9em;
+    font-size: 0.88em;
   }
 
   .prose pre {
-    background: #0f0f0f;
+    background: #1a1a1a;
     border: 1px solid var(--rule);
-    padding: 20px;
-    border-radius: 4px;
+    padding: 24px;
+    border-radius: 6px;
     overflow-x: auto;
-    margin: 1.5em 0;
+    margin: 1.75em 0;
     font-size: 13px;
-    line-height: 1.5;
+    line-height: 1.55;
   }
 
   .prose pre code {
@@ -258,40 +289,54 @@ const formattedUpdated = updatedDate?.toLocaleDateString('en-US', {
     max-width: 100%;
     height: auto;
     margin: 2em 0;
-    border-radius: 4px;
+    border-radius: 6px;
   }
 
+  /* Footer */
   .footer {
-    margin-top: 96px;
+    max-width: 1080px;
+    margin: 120px auto 0;
     padding-top: 32px;
     border-top: 1px solid var(--rule);
     display: flex;
     justify-content: space-between;
-    color: var(--muted);
+    color: var(--dim);
     font-size: 12px;
-    letter-spacing: 0.05em;
+    letter-spacing: 0.08em;
     text-transform: uppercase;
   }
 
   .footer a {
-    color: var(--muted);
+    color: var(--dim);
     text-decoration: none;
+    transition: color 0.2s;
   }
 
   .footer a:hover { color: var(--text); }
 
-  .updated-note {
-    margin-top: 8px;
-    color: var(--dim);
-    font-size: 12px;
+  ::selection { background: #555; color: #fff; }
+
+  @media (max-width: 900px) {
+    .wrap { padding: 120px 32px 80px; }
+    .article-body {
+      grid-template-columns: 1fr;
+      gap: 48px;
+    }
+    .meta-rail {
+      position: static;
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+      gap: 24px;
+    }
+    .meta-block { margin-bottom: 0; }
+    .meta-tags { flex-direction: row; flex-wrap: wrap; gap: 12px; }
+    .prose { max-width: none; }
   }
 
-  ::selection { background: #444; color: #fff; }
-
-  @media (max-width: 640px) {
-    .container { padding: 48px 24px 80px; }
-    .article-title { font-size: 26px; }
-    .article-description { font-size: 16px; }
+  @media (max-width: 600px) {
+    .wrap { padding: 100px 24px 64px; }
+    .article-header { margin-bottom: 56px; }
+    .article-description { font-size: 17px; }
     .prose { font-size: 16px; }
   }
 </style>
@@ -303,34 +348,44 @@ const formattedUpdated = updatedDate?.toLocaleDateString('en-US', {
   <a href="/rss.xml">RSS</a>
 </nav>
 
-<div class="container">
+<div class="wrap">
   <header class="article-header">
     <div class="article-eyebrow">Note</div>
     <h1 class="article-title">{title}</h1>
     <p class="article-description">{description}</p>
-    <div class="article-meta">
-      <time datetime={publishDate.toISOString()}>{formattedDate}</time>
-      <span class="sep">·</span>
-      <span>{stats.minutes} min read</span>
-      <span class="sep">·</span>
-      <span>{stats.words.toLocaleString()} words</span>
-      {tags.length > 0 && <span class="sep">·</span>}
-      {tags.length > 0 && (
-        <div class="article-tags">
-          {tags.map((tag) => (
-            <a href={`/notes/tag/${tagSlug(tag)}`}>#{tag}</a>
-          ))}
-        </div>
-      )}
-    </div>
-    {formattedUpdated && (
-      <div class="updated-note">Last updated {formattedUpdated}</div>
-    )}
   </header>
 
-  <article class="prose">
-    <Content />
-  </article>
+  <div class="article-body">
+    <aside class="meta-rail">
+      <div class="meta-block">
+        <div class="meta-label">Published</div>
+        <time class="meta-value" datetime={publishDate.toISOString()}>{formattedDate}</time>
+        {formattedUpdated && (
+          <div class="updated-line">Updated {formattedUpdated}</div>
+        )}
+      </div>
+
+      <div class="meta-block">
+        <div class="meta-label">Read</div>
+        <div class="meta-value">{stats.minutes} min &middot; {stats.words.toLocaleString()} words</div>
+      </div>
+
+      {tags.length > 0 && (
+        <div class="meta-block">
+          <div class="meta-label">Tags</div>
+          <div class="meta-tags">
+            {tags.map((tag) => (
+              <a href={`/notes/tag/${tagSlug(tag)}`}>#{tag}</a>
+            ))}
+          </div>
+        </div>
+      )}
+    </aside>
+
+    <article class="prose">
+      <Content />
+    </article>
+  </div>
 
   <footer class="footer">
     <a href="/notes">&larr; All notes</a>

--- a/src/pages/notes/index.astro
+++ b/src/pages/notes/index.astro
@@ -23,17 +23,17 @@ const noteStats = new Map(
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<title>Notes — Nilson Gaspar</title>
-<meta name="title" content="Notes — Nilson Gaspar">
+<title>Notes | Nilson Gaspar</title>
+<meta name="title" content="Notes | Nilson Gaspar">
 <meta name="description" content="Design essays and thinking by Nilson Gaspar.">
 <meta name="author" content="Nilson Gaspar">
 
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://nilsongaspar.com/notes/">
-<meta property="og:title" content="Notes — Nilson Gaspar">
+<meta property="og:title" content="Notes | Nilson Gaspar">
 <meta property="og:description" content="Design essays and thinking by Nilson Gaspar.">
 
-<link rel="alternate" type="application/rss+xml" title="Nilson Gaspar — Notes" href="/rss.xml">
+<link rel="alternate" type="application/rss+xml" title="Nilson Gaspar Notes" href="/rss.xml">
 
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="icon" type="image/png" href="/favicon.png">
@@ -42,12 +42,12 @@ const noteStats = new Map(
   * { margin: 0; padding: 0; box-sizing: border-box; }
 
   :root {
-    --bg: #1a1a1a;
-    --text: #e8e8e8;
-    --muted: #888;
-    --dim: #555;
+    --bg: #30302e;
+    --text: #ffffff;
+    --muted: #aaa;
+    --dim: #888;
+    --faint: #666;
     --rule: rgba(255, 255, 255, 0.08);
-    --accent: #e8e8e8;
   }
 
   body {
@@ -61,130 +61,146 @@ const noteStats = new Map(
   }
 
   .nav {
-    padding: 32px 48px;
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    padding: 24px 48px;
+    background: linear-gradient(to bottom, var(--bg) 0%, transparent 100%);
+    z-index: 100;
+    backdrop-filter: blur(10px);
     display: flex;
     justify-content: space-between;
     align-items: baseline;
   }
 
-  .nav a, .nav span {
-    color: var(--muted);
+  .nav a {
+    color: var(--dim);
     text-decoration: none;
-    font-size: 12px;
-    letter-spacing: 0.05em;
+    font-size: 13px;
+    letter-spacing: 0.08em;
     text-transform: uppercase;
+    transition: color 0.2s;
   }
 
   .nav a:hover { color: var(--text); }
 
-  .container {
-    max-width: 720px;
+  .wrap {
+    max-width: 1200px;
     margin: 0 auto;
-    padding: 80px 48px 120px;
+    padding: 140px 48px 120px;
   }
 
+  /* Header */
   .page-header {
+    display: grid;
+    grid-template-columns: 200px 1fr;
+    gap: 80px;
     margin-bottom: 96px;
-    padding-bottom: 32px;
+    padding-bottom: 48px;
     border-bottom: 1px solid var(--rule);
   }
 
-  .page-title {
-    font-size: 14px;
-    font-weight: 400;
-    color: var(--muted);
+  .page-label {
+    font-size: 12px;
+    color: var(--faint);
     text-transform: uppercase;
-    letter-spacing: 0.1em;
-    margin-bottom: 16px;
+    letter-spacing: 0.15em;
+    padding-top: 8px;
   }
 
   .page-description {
-    font-size: 16px;
+    font-family: -apple-system, BlinkMacSystemFont, "SF Pro Display", "Inter", system-ui, sans-serif;
+    font-size: 24px;
+    font-weight: 300;
+    line-height: 1.45;
     color: var(--text);
-    line-height: 1.6;
-    max-width: 560px;
+    max-width: 700px;
   }
 
   .tag-bar {
-    margin-top: 32px;
+    grid-column: 2;
+    margin-top: 24px;
     display: flex;
     flex-wrap: wrap;
-    gap: 8px 16px;
+    gap: 8px 20px;
   }
 
   .tag-bar a {
-    color: var(--muted);
+    color: var(--dim);
     text-decoration: none;
     font-size: 13px;
-    transition: color 0.15s;
+    transition: color 0.2s;
   }
 
   .tag-bar a:hover { color: var(--text); }
 
+  /* Year groups */
   .year-group {
-    margin-bottom: 72px;
+    display: grid;
+    grid-template-columns: 200px 1fr;
+    gap: 80px;
+    margin-bottom: 80px;
   }
 
   .year-label {
-    font-size: 12px;
-    color: var(--dim);
-    letter-spacing: 0.1em;
-    margin-bottom: 24px;
-    display: flex;
-    align-items: center;
-    gap: 16px;
-  }
-
-  .year-label::after {
-    content: '';
-    flex: 1;
-    height: 1px;
-    background: var(--rule);
+    font-family: -apple-system, BlinkMacSystemFont, "SF Pro Display", "Inter", system-ui, sans-serif;
+    font-size: 56px;
+    font-weight: 300;
+    color: var(--faint);
+    letter-spacing: -0.02em;
+    line-height: 1;
+    position: sticky;
+    top: 120px;
+    align-self: start;
   }
 
   .note-list {
-    list-style: none;
     display: flex;
     flex-direction: column;
+    max-width: 880px;
   }
 
   .note-item {
     display: grid;
-    grid-template-columns: 64px 1fr auto;
+    grid-template-columns: 80px 1fr auto;
     align-items: baseline;
-    gap: 24px;
-    padding: 16px 0;
+    gap: 32px;
+    padding: 20px 0;
     border-bottom: 1px solid var(--rule);
     text-decoration: none;
     color: var(--text);
-    transition: background 0.15s;
+    transition: padding 0.2s, color 0.2s;
   }
 
   .note-item:hover {
-    background: rgba(255, 255, 255, 0.02);
+    padding-left: 8px;
   }
 
-  .note-item:hover .note-title {
-    color: #fff;
-  }
+  .note-item:hover .note-title { color: #fff; }
+  .note-item:hover .note-date { color: var(--muted); }
 
   .note-date {
-    color: var(--dim);
+    color: var(--faint);
     font-size: 13px;
     font-variant-numeric: tabular-nums;
+    letter-spacing: 0.02em;
+    transition: color 0.2s;
   }
 
   .note-title {
+    font-family: -apple-system, BlinkMacSystemFont, "SF Pro Display", "Inter", system-ui, sans-serif;
     color: var(--text);
-    font-size: 15px;
-    line-height: 1.5;
-    transition: color 0.15s;
+    font-size: 20px;
+    font-weight: 400;
+    line-height: 1.35;
+    transition: color 0.2s;
   }
 
   .note-meta {
-    color: var(--dim);
+    color: var(--faint);
     font-size: 12px;
-    letter-spacing: 0.02em;
+    letter-spacing: 0.04em;
     white-space: nowrap;
   }
 
@@ -194,34 +210,51 @@ const noteStats = new Map(
     padding: 48px 0;
   }
 
+  /* Footer */
   .footer {
-    margin-top: 96px;
+    max-width: 1200px;
+    margin: 80px auto 0;
     padding-top: 32px;
     border-top: 1px solid var(--rule);
     display: flex;
     justify-content: space-between;
-    color: var(--muted);
+    color: var(--dim);
     font-size: 12px;
-    letter-spacing: 0.05em;
+    letter-spacing: 0.08em;
     text-transform: uppercase;
   }
 
   .footer a {
-    color: var(--muted);
+    color: var(--dim);
     text-decoration: none;
+    transition: color 0.2s;
   }
 
   .footer a:hover { color: var(--text); }
 
-  ::selection { background: #444; color: #fff; }
+  ::selection { background: #555; color: #fff; }
 
-  @media (max-width: 640px) {
-    .container { padding: 48px 24px 80px; }
+  @media (max-width: 900px) {
+    .wrap { padding: 120px 32px 80px; }
+    .page-header, .year-group {
+      grid-template-columns: 1fr;
+      gap: 24px;
+    }
+    .page-description { font-size: 20px; }
+    .tag-bar { grid-column: 1; margin-top: 16px; }
+    .year-label { position: static; font-size: 36px; }
+    .note-item { grid-template-columns: 64px 1fr auto; gap: 16px; }
+  }
+
+  @media (max-width: 600px) {
+    .wrap { padding: 100px 24px 64px; }
     .note-item {
       grid-template-columns: 1fr;
       gap: 4px;
+      padding: 16px 0;
     }
-    .note-date { font-size: 12px; }
+    .note-item:hover { padding-left: 0; }
+    .note-title { font-size: 17px; }
     .note-meta { font-size: 11px; }
   }
 </style>
@@ -233,19 +266,21 @@ const noteStats = new Map(
   <a href="/rss.xml">RSS</a>
 </nav>
 
-<div class="container">
+<div class="wrap">
   <header class="page-header">
-    <div class="page-title">Notes</div>
-    <p class="page-description">
-      Design essays and thinking. Written from practice — what I notice while shipping, mentoring, and working with tools.
-    </p>
-    {allTags.length > 0 && (
-      <div class="tag-bar">
-        {allTags.map((tag) => (
-          <a href={`/notes/tag/${tagSlug(tag)}`}>#{tag}</a>
-        ))}
-      </div>
-    )}
+    <div class="page-label">Notes</div>
+    <div>
+      <p class="page-description">
+        Design essays and thinking. Written from practice. What I notice while shipping, mentoring, and working with tools.
+      </p>
+      {allTags.length > 0 && (
+        <div class="tag-bar">
+          {allTags.map((tag) => (
+            <a href={`/notes/tag/${tagSlug(tag)}`}>#{tag}</a>
+          ))}
+        </div>
+      )}
+    </div>
   </header>
 
   {notes.length === 0 ? (

--- a/src/pages/notes/index.astro
+++ b/src/pages/notes/index.astro
@@ -1,0 +1,280 @@
+---
+import {
+  getPublishedNotes,
+  groupByYear,
+  getAllTags,
+  getNoteStats,
+  formatDate,
+  tagSlug,
+} from '../../lib/notes';
+
+const notes = await getPublishedNotes();
+const grouped = groupByYear(notes);
+const allTags = getAllTags(notes);
+
+const noteStats = new Map(
+  notes.map((n) => [n.slug, getNoteStats(n.body)]),
+);
+---
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Notes — Nilson Gaspar</title>
+<meta name="title" content="Notes — Nilson Gaspar">
+<meta name="description" content="Design essays and thinking by Nilson Gaspar.">
+<meta name="author" content="Nilson Gaspar">
+
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://nilsongaspar.com/notes/">
+<meta property="og:title" content="Notes — Nilson Gaspar">
+<meta property="og:description" content="Design essays and thinking by Nilson Gaspar.">
+
+<link rel="alternate" type="application/rss+xml" title="Nilson Gaspar — Notes" href="/rss.xml">
+
+<link rel="icon" type="image/svg+xml" href="/favicon.svg">
+<link rel="icon" type="image/png" href="/favicon.png">
+
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+
+  :root {
+    --bg: #1a1a1a;
+    --text: #e8e8e8;
+    --muted: #888;
+    --dim: #555;
+    --rule: rgba(255, 255, 255, 0.08);
+    --accent: #e8e8e8;
+  }
+
+  body {
+    background: var(--bg);
+    color: var(--text);
+    font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+    font-size: 14px;
+    line-height: 1.6;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
+
+  .nav {
+    padding: 32px 48px;
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+  }
+
+  .nav a, .nav span {
+    color: var(--muted);
+    text-decoration: none;
+    font-size: 12px;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+  }
+
+  .nav a:hover { color: var(--text); }
+
+  .container {
+    max-width: 720px;
+    margin: 0 auto;
+    padding: 80px 48px 120px;
+  }
+
+  .page-header {
+    margin-bottom: 96px;
+    padding-bottom: 32px;
+    border-bottom: 1px solid var(--rule);
+  }
+
+  .page-title {
+    font-size: 14px;
+    font-weight: 400;
+    color: var(--muted);
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    margin-bottom: 16px;
+  }
+
+  .page-description {
+    font-size: 16px;
+    color: var(--text);
+    line-height: 1.6;
+    max-width: 560px;
+  }
+
+  .tag-bar {
+    margin-top: 32px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px 16px;
+  }
+
+  .tag-bar a {
+    color: var(--muted);
+    text-decoration: none;
+    font-size: 13px;
+    transition: color 0.15s;
+  }
+
+  .tag-bar a:hover { color: var(--text); }
+
+  .year-group {
+    margin-bottom: 72px;
+  }
+
+  .year-label {
+    font-size: 12px;
+    color: var(--dim);
+    letter-spacing: 0.1em;
+    margin-bottom: 24px;
+    display: flex;
+    align-items: center;
+    gap: 16px;
+  }
+
+  .year-label::after {
+    content: '';
+    flex: 1;
+    height: 1px;
+    background: var(--rule);
+  }
+
+  .note-list {
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .note-item {
+    display: grid;
+    grid-template-columns: 64px 1fr auto;
+    align-items: baseline;
+    gap: 24px;
+    padding: 16px 0;
+    border-bottom: 1px solid var(--rule);
+    text-decoration: none;
+    color: var(--text);
+    transition: background 0.15s;
+  }
+
+  .note-item:hover {
+    background: rgba(255, 255, 255, 0.02);
+  }
+
+  .note-item:hover .note-title {
+    color: #fff;
+  }
+
+  .note-date {
+    color: var(--dim);
+    font-size: 13px;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .note-title {
+    color: var(--text);
+    font-size: 15px;
+    line-height: 1.5;
+    transition: color 0.15s;
+  }
+
+  .note-meta {
+    color: var(--dim);
+    font-size: 12px;
+    letter-spacing: 0.02em;
+    white-space: nowrap;
+  }
+
+  .empty {
+    color: var(--muted);
+    font-style: italic;
+    padding: 48px 0;
+  }
+
+  .footer {
+    margin-top: 96px;
+    padding-top: 32px;
+    border-top: 1px solid var(--rule);
+    display: flex;
+    justify-content: space-between;
+    color: var(--muted);
+    font-size: 12px;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+  }
+
+  .footer a {
+    color: var(--muted);
+    text-decoration: none;
+  }
+
+  .footer a:hover { color: var(--text); }
+
+  ::selection { background: #444; color: #fff; }
+
+  @media (max-width: 640px) {
+    .container { padding: 48px 24px 80px; }
+    .note-item {
+      grid-template-columns: 1fr;
+      gap: 4px;
+    }
+    .note-date { font-size: 12px; }
+    .note-meta { font-size: 11px; }
+  }
+</style>
+</head>
+<body>
+
+<nav class="nav">
+  <a href="/">&larr; Back</a>
+  <a href="/rss.xml">RSS</a>
+</nav>
+
+<div class="container">
+  <header class="page-header">
+    <div class="page-title">Notes</div>
+    <p class="page-description">
+      Design essays and thinking. Written from practice — what I notice while shipping, mentoring, and working with tools.
+    </p>
+    {allTags.length > 0 && (
+      <div class="tag-bar">
+        {allTags.map((tag) => (
+          <a href={`/notes/tag/${tagSlug(tag)}`}>#{tag}</a>
+        ))}
+      </div>
+    )}
+  </header>
+
+  {notes.length === 0 ? (
+    <p class="empty">No notes published yet.</p>
+  ) : (
+    grouped.map(([year, yearNotes]) => (
+      <section class="year-group">
+        <div class="year-label">{year}</div>
+        <div class="note-list">
+          {yearNotes.map((note) => {
+            const stats = noteStats.get(note.slug)!;
+            return (
+              <a href={`/notes/${note.slug}`} class="note-item">
+                <span class="note-date">{formatDate(note.data.publishDate)}</span>
+                <span class="note-title">{note.data.title}</span>
+                <span class="note-meta">{stats.minutes} min</span>
+              </a>
+            );
+          })}
+        </div>
+      </section>
+    ))
+  )}
+
+  <footer class="footer">
+    <a href="/">Home</a>
+    <a href="/rss.xml">Subscribe via RSS</a>
+  </footer>
+</div>
+
+</body>
+</html>

--- a/src/pages/notes/tag/[tag].astro
+++ b/src/pages/notes/tag/[tag].astro
@@ -40,10 +40,10 @@ const noteStats = new Map(
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<title>{`#${tag}`} — Notes — Nilson Gaspar</title>
+<title>{`#${tag}`} | Notes | Nilson Gaspar</title>
 <meta name="description" content={`Notes tagged ${tag}.`}>
 
-<link rel="alternate" type="application/rss+xml" title="Nilson Gaspar — Notes" href="/rss.xml">
+<link rel="alternate" type="application/rss+xml" title="Nilson Gaspar Notes" href="/rss.xml">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="icon" type="image/png" href="/favicon.png">
 
@@ -51,10 +51,11 @@ const noteStats = new Map(
   * { margin: 0; padding: 0; box-sizing: border-box; }
 
   :root {
-    --bg: #1a1a1a;
-    --text: #e8e8e8;
-    --muted: #888;
-    --dim: #555;
+    --bg: #30302e;
+    --text: #ffffff;
+    --muted: #aaa;
+    --dim: #888;
+    --faint: #666;
     --rule: rgba(255, 255, 255, 0.08);
   }
 
@@ -69,133 +70,175 @@ const noteStats = new Map(
   }
 
   .nav {
-    padding: 32px 48px;
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    padding: 24px 48px;
+    background: linear-gradient(to bottom, var(--bg) 0%, transparent 100%);
+    z-index: 100;
+    backdrop-filter: blur(10px);
     display: flex;
     justify-content: space-between;
     align-items: baseline;
   }
 
   .nav a {
-    color: var(--muted);
+    color: var(--dim);
     text-decoration: none;
-    font-size: 12px;
-    letter-spacing: 0.05em;
+    font-size: 13px;
+    letter-spacing: 0.08em;
     text-transform: uppercase;
+    transition: color 0.2s;
   }
 
   .nav a:hover { color: var(--text); }
 
-  .container {
-    max-width: 720px;
+  .wrap {
+    max-width: 1200px;
     margin: 0 auto;
-    padding: 80px 48px 120px;
+    padding: 140px 48px 120px;
   }
 
   .page-header {
-    margin-bottom: 64px;
-    padding-bottom: 32px;
+    display: grid;
+    grid-template-columns: 200px 1fr;
+    gap: 80px;
+    margin-bottom: 96px;
+    padding-bottom: 48px;
     border-bottom: 1px solid var(--rule);
   }
 
-  .page-eyebrow {
+  .page-label {
     font-size: 12px;
-    color: var(--dim);
-    letter-spacing: 0.1em;
+    color: var(--faint);
     text-transform: uppercase;
-    margin-bottom: 16px;
+    letter-spacing: 0.15em;
+    padding-top: 16px;
   }
 
   .page-title {
     font-family: -apple-system, BlinkMacSystemFont, "SF Pro Display", "Inter", system-ui, sans-serif;
-    font-size: 28px;
+    font-size: clamp(36px, 5vw, 56px);
     font-weight: 600;
     color: #fff;
-    letter-spacing: -0.02em;
+    letter-spacing: -0.025em;
+    line-height: 1.05;
   }
 
   .page-count {
-    color: var(--muted);
+    color: var(--dim);
     font-size: 14px;
-    margin-top: 8px;
+    margin-top: 16px;
   }
 
-  .year-group { margin-bottom: 72px; }
+  .year-group {
+    display: grid;
+    grid-template-columns: 200px 1fr;
+    gap: 80px;
+    margin-bottom: 80px;
+  }
 
   .year-label {
-    font-size: 12px;
-    color: var(--dim);
-    letter-spacing: 0.1em;
-    margin-bottom: 24px;
+    font-family: -apple-system, BlinkMacSystemFont, "SF Pro Display", "Inter", system-ui, sans-serif;
+    font-size: 56px;
+    font-weight: 300;
+    color: var(--faint);
+    letter-spacing: -0.02em;
+    line-height: 1;
+    position: sticky;
+    top: 120px;
+    align-self: start;
+  }
+
+  .note-list {
     display: flex;
-    align-items: center;
-    gap: 16px;
+    flex-direction: column;
+    max-width: 880px;
   }
-
-  .year-label::after {
-    content: '';
-    flex: 1;
-    height: 1px;
-    background: var(--rule);
-  }
-
-  .note-list { display: flex; flex-direction: column; }
 
   .note-item {
     display: grid;
-    grid-template-columns: 64px 1fr auto;
+    grid-template-columns: 80px 1fr auto;
     align-items: baseline;
-    gap: 24px;
-    padding: 16px 0;
+    gap: 32px;
+    padding: 20px 0;
     border-bottom: 1px solid var(--rule);
     text-decoration: none;
     color: var(--text);
-    transition: background 0.15s;
+    transition: padding 0.2s, color 0.2s;
   }
 
-  .note-item:hover { background: rgba(255, 255, 255, 0.02); }
+  .note-item:hover { padding-left: 8px; }
   .note-item:hover .note-title { color: #fff; }
+  .note-item:hover .note-date { color: var(--muted); }
 
   .note-date {
-    color: var(--dim);
+    color: var(--faint);
     font-size: 13px;
     font-variant-numeric: tabular-nums;
+    letter-spacing: 0.02em;
+    transition: color 0.2s;
   }
 
   .note-title {
+    font-family: -apple-system, BlinkMacSystemFont, "SF Pro Display", "Inter", system-ui, sans-serif;
     color: var(--text);
-    font-size: 15px;
-    line-height: 1.5;
-    transition: color 0.15s;
+    font-size: 20px;
+    font-weight: 400;
+    line-height: 1.35;
+    transition: color 0.2s;
   }
 
   .note-meta {
-    color: var(--dim);
+    color: var(--faint);
     font-size: 12px;
-    letter-spacing: 0.02em;
+    letter-spacing: 0.04em;
     white-space: nowrap;
   }
 
   .footer {
-    margin-top: 96px;
+    max-width: 1200px;
+    margin: 80px auto 0;
     padding-top: 32px;
     border-top: 1px solid var(--rule);
     display: flex;
     justify-content: space-between;
-    color: var(--muted);
+    color: var(--dim);
     font-size: 12px;
-    letter-spacing: 0.05em;
+    letter-spacing: 0.08em;
     text-transform: uppercase;
   }
 
-  .footer a { color: var(--muted); text-decoration: none; }
+  .footer a {
+    color: var(--dim);
+    text-decoration: none;
+    transition: color 0.2s;
+  }
+
   .footer a:hover { color: var(--text); }
 
-  ::selection { background: #444; color: #fff; }
+  ::selection { background: #555; color: #fff; }
 
-  @media (max-width: 640px) {
-    .container { padding: 48px 24px 80px; }
-    .note-item { grid-template-columns: 1fr; gap: 4px; }
-    .note-date { font-size: 12px; }
+  @media (max-width: 900px) {
+    .wrap { padding: 120px 32px 80px; }
+    .page-header, .year-group {
+      grid-template-columns: 1fr;
+      gap: 24px;
+    }
+    .year-label { position: static; font-size: 36px; }
+    .note-item { grid-template-columns: 64px 1fr auto; gap: 16px; }
+  }
+
+  @media (max-width: 600px) {
+    .wrap { padding: 100px 24px 64px; }
+    .note-item {
+      grid-template-columns: 1fr;
+      gap: 4px;
+      padding: 16px 0;
+    }
+    .note-item:hover { padding-left: 0; }
+    .note-title { font-size: 17px; }
     .note-meta { font-size: 11px; }
   }
 </style>
@@ -207,11 +250,13 @@ const noteStats = new Map(
   <a href="/rss.xml">RSS</a>
 </nav>
 
-<div class="container">
+<div class="wrap">
   <header class="page-header">
-    <div class="page-eyebrow">Tag</div>
-    <h1 class="page-title">#{tag}</h1>
-    <div class="page-count">{notes.length} {notes.length === 1 ? 'note' : 'notes'}</div>
+    <div class="page-label">Tag</div>
+    <div>
+      <h1 class="page-title">#{tag}</h1>
+      <div class="page-count">{notes.length} {notes.length === 1 ? 'note' : 'notes'}</div>
+    </div>
   </header>
 
   {grouped.map(([year, yearNotes]) => (

--- a/src/pages/notes/tag/[tag].astro
+++ b/src/pages/notes/tag/[tag].astro
@@ -1,0 +1,242 @@
+---
+import {
+  getPublishedNotes,
+  groupByYear,
+  getAllTags,
+  getNoteStats,
+  formatDate,
+  tagSlug,
+  type Note,
+} from '../../../lib/notes';
+
+export async function getStaticPaths() {
+  const notes = await getPublishedNotes();
+  const tags = getAllTags(notes);
+  return tags.map((tag) => {
+    const slug = tagSlug(tag);
+    const filtered = notes.filter((n) => n.data.tags.includes(tag));
+    return {
+      params: { tag: slug },
+      props: { tag, notes: filtered },
+    };
+  });
+}
+
+interface Props {
+  tag: string;
+  notes: Note[];
+}
+
+const { tag, notes } = Astro.props;
+const grouped = groupByYear(notes);
+const noteStats = new Map(
+  notes.map((n) => [n.slug, getNoteStats(n.body)]),
+);
+---
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>{`#${tag}`} — Notes — Nilson Gaspar</title>
+<meta name="description" content={`Notes tagged ${tag}.`}>
+
+<link rel="alternate" type="application/rss+xml" title="Nilson Gaspar — Notes" href="/rss.xml">
+<link rel="icon" type="image/svg+xml" href="/favicon.svg">
+<link rel="icon" type="image/png" href="/favicon.png">
+
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+
+  :root {
+    --bg: #1a1a1a;
+    --text: #e8e8e8;
+    --muted: #888;
+    --dim: #555;
+    --rule: rgba(255, 255, 255, 0.08);
+  }
+
+  body {
+    background: var(--bg);
+    color: var(--text);
+    font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+    font-size: 14px;
+    line-height: 1.6;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
+
+  .nav {
+    padding: 32px 48px;
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+  }
+
+  .nav a {
+    color: var(--muted);
+    text-decoration: none;
+    font-size: 12px;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+  }
+
+  .nav a:hover { color: var(--text); }
+
+  .container {
+    max-width: 720px;
+    margin: 0 auto;
+    padding: 80px 48px 120px;
+  }
+
+  .page-header {
+    margin-bottom: 64px;
+    padding-bottom: 32px;
+    border-bottom: 1px solid var(--rule);
+  }
+
+  .page-eyebrow {
+    font-size: 12px;
+    color: var(--dim);
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    margin-bottom: 16px;
+  }
+
+  .page-title {
+    font-family: -apple-system, BlinkMacSystemFont, "SF Pro Display", "Inter", system-ui, sans-serif;
+    font-size: 28px;
+    font-weight: 600;
+    color: #fff;
+    letter-spacing: -0.02em;
+  }
+
+  .page-count {
+    color: var(--muted);
+    font-size: 14px;
+    margin-top: 8px;
+  }
+
+  .year-group { margin-bottom: 72px; }
+
+  .year-label {
+    font-size: 12px;
+    color: var(--dim);
+    letter-spacing: 0.1em;
+    margin-bottom: 24px;
+    display: flex;
+    align-items: center;
+    gap: 16px;
+  }
+
+  .year-label::after {
+    content: '';
+    flex: 1;
+    height: 1px;
+    background: var(--rule);
+  }
+
+  .note-list { display: flex; flex-direction: column; }
+
+  .note-item {
+    display: grid;
+    grid-template-columns: 64px 1fr auto;
+    align-items: baseline;
+    gap: 24px;
+    padding: 16px 0;
+    border-bottom: 1px solid var(--rule);
+    text-decoration: none;
+    color: var(--text);
+    transition: background 0.15s;
+  }
+
+  .note-item:hover { background: rgba(255, 255, 255, 0.02); }
+  .note-item:hover .note-title { color: #fff; }
+
+  .note-date {
+    color: var(--dim);
+    font-size: 13px;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .note-title {
+    color: var(--text);
+    font-size: 15px;
+    line-height: 1.5;
+    transition: color 0.15s;
+  }
+
+  .note-meta {
+    color: var(--dim);
+    font-size: 12px;
+    letter-spacing: 0.02em;
+    white-space: nowrap;
+  }
+
+  .footer {
+    margin-top: 96px;
+    padding-top: 32px;
+    border-top: 1px solid var(--rule);
+    display: flex;
+    justify-content: space-between;
+    color: var(--muted);
+    font-size: 12px;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+  }
+
+  .footer a { color: var(--muted); text-decoration: none; }
+  .footer a:hover { color: var(--text); }
+
+  ::selection { background: #444; color: #fff; }
+
+  @media (max-width: 640px) {
+    .container { padding: 48px 24px 80px; }
+    .note-item { grid-template-columns: 1fr; gap: 4px; }
+    .note-date { font-size: 12px; }
+    .note-meta { font-size: 11px; }
+  }
+</style>
+</head>
+<body>
+
+<nav class="nav">
+  <a href="/notes">&larr; All notes</a>
+  <a href="/rss.xml">RSS</a>
+</nav>
+
+<div class="container">
+  <header class="page-header">
+    <div class="page-eyebrow">Tag</div>
+    <h1 class="page-title">#{tag}</h1>
+    <div class="page-count">{notes.length} {notes.length === 1 ? 'note' : 'notes'}</div>
+  </header>
+
+  {grouped.map(([year, yearNotes]) => (
+    <section class="year-group">
+      <div class="year-label">{year}</div>
+      <div class="note-list">
+        {yearNotes.map((note) => {
+          const stats = noteStats.get(note.slug)!;
+          return (
+            <a href={`/notes/${note.slug}`} class="note-item">
+              <span class="note-date">{formatDate(note.data.publishDate)}</span>
+              <span class="note-title">{note.data.title}</span>
+              <span class="note-meta">{stats.minutes} min</span>
+            </a>
+          );
+        })}
+      </div>
+    </section>
+  ))}
+
+  <footer class="footer">
+    <a href="/notes">&larr; All notes</a>
+    <a href="/">Home</a>
+  </footer>
+</div>
+
+</body>
+</html>

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -1,0 +1,20 @@
+import rss from '@astrojs/rss';
+import type { APIContext } from 'astro';
+import { getPublishedNotes } from '../lib/notes';
+
+export async function GET(context: APIContext) {
+  const notes = await getPublishedNotes();
+  return rss({
+    title: 'Nilson Gaspar — Notes',
+    description: 'Design essays and thinking by Nilson Gaspar.',
+    site: context.site ?? 'https://nilsongaspar.com',
+    items: notes.map((note) => ({
+      title: note.data.title,
+      description: note.data.description,
+      pubDate: note.data.publishDate,
+      link: `/notes/${note.slug}`,
+      categories: note.data.tags,
+    })),
+    customData: '<language>en-us</language>',
+  });
+}


### PR DESCRIPTION
## Summary
A minimal/utilitarian notes system for design essays and long-form thinking.

### What's shipped
- **`/notes`** — year-grouped archive listing (date · title · reading time)
- **`/notes/[slug]`** — minimal essay layout: monospace metadata, sans body, narrow column, reading time + word count
- **`/notes/tag/[tag]`** — per-tag filtered listings (auto-generated from frontmatter)
- **`/rss.xml`** — full RSS feed with categories
- **First note**: "Reality and Fiction in Figma"

### Content schema
```yaml
title: string
description: string
publishDate: date
updatedDate: date (optional)
tags: string[]
draft: bool (drafts excluded in production builds)
featured: bool
```

Filename = slug. Drop a `.md` or `.mdx` file into `src/content/notes/` and it appears automatically.

### Tech
- `reading-time` package — auto-calculates min read + word count
- `@astrojs/rss` — feed generation
- Site URL configured: https://nilsongaspar.com

## Test plan
- [ ] `/notes` shows the archive with the first note under 2026
- [ ] Click into note → reads cleanly, shows date / reading time / word count / tags
- [ ] Click a tag → lands on `/notes/tag/[tag]` with filtered list
- [ ] `/rss.xml` returns valid feed
- [ ] Homepage "EXPLORE MY NOTES" still points to `/notes`

🤖 Generated with [Claude Code](https://claude.com/claude-code)