### PR TITLE
Add note: Inside Context, Outside Eyes

### DIFF
--- a/src/content/notes/inside-context-outside-eyes.md
+++ b/src/content/notes/inside-context-outside-eyes.md
@@ -1,0 +1,22 @@
+---
+title: 'Inside Context, Outside Eyes'
+description: "Recording my own prototypes lets me review them as if they were someone else's work. How to keep a maker's context while borrowing an outsider's eyes."
+publishDate: 2026-06-01
+tags: ['design', 'process', 'feedback']
+---
+
+Back when I was at Dynatrace, I designed the onboarding for Spaces. I'd built the flow, tested it myself, and it felt right. Then I recorded the whole thing start to finish, and watching it back, one small thing started to nag at me: a button state I'd used because it looked right to me, and because the design system defined it that way. Something about it felt off in a way I'd never registered while building.
+
+This happens every time I record. I record prototypes to share with stakeholders and to keep a kind of iteration log, how it started, how it's going. But watching them back became something else. While I'm building, the flaws are invisible to me. A micro-interaction missing, an element positioned slightly wrong, small things I'd mentally noted to refine and then skipped past. Only on the recording do I see them.
+
+Watching the recording lets me review the work as if it were someone else's. Unbiased, not blocked by creator association. When someone asks me to review their work, I can be impartial and honest in a way I can't be with my own. The recording lets me borrow that same impartiality. It detaches me, emotionally, from the thing I made.
+
+But it's better than handing the work to an actual outside reviewer. At most companies there's a weekly moment where designers share work for visibility and feedback, and what I noticed there is that people responding only see a snapshot. They don't know your constraints, your intentions, what you already ruled out, so their feedback can only ever be partial. Watching my own recording gives me what that critique can't. I keep all of that context, because I built the thing, and I still get the outside view. I catch the small concrete things an outsider would, an element out of alignment, a missing step where the prototype jumps ahead and needs another screen to show the user what happens next. Inside context and outside eyes at the same time.
+
+I'm now comfortable summoning that outsider feeling at every stage, not just on a finished recording. I ask myself: why does this decision make sense right now? Is there a better way? A different way?
+
+Back to that button state from the Spaces onboarding. Once the recording made it nag at me, I dug in. The problem was visual dominance. Two buttons sat side by side, the same component in two different states, and one pulled far more attention than it should have next to the other. I compared the design system's treatment against how more mature companies handled the same pairing, which confirmed why it had felt off. So I explored alternatives and brought them to the wider design team, partly to get their read, partly to learn whether they'd felt the same friction. That is usually how it goes: the questions push me to explore, so the people I work with see several attempts, not one.
+
+None of this discourages me. Just the opposite. Finding flaws in my work reassures me, because it tells me there's a second path, a third, a fourth, beyond the one I started down. I'm never fully certain the first direction is the right one. The work goes: do, look, think, do more, review, iterate. My early versions are rarely all the way on track, so catching their flaws is what tells me I can keep going, keep pulling the threads.
+
+I believe distance is learnable because I learned it myself. No one taught me, and I've since taught it to others. When a mentee struggles to separate themselves from a critique, I tell them the same thing: the critique is aimed at the exploration they're presenting, not at them. Once that lands, feedback stops being an attack and starts being a clue, a hint about how to shape the next version.


### PR DESCRIPTION
## Summary
- New note on reviewing your own design work with an outsider's impartiality by recording prototypes and watching them back
- Tags: design, process, feedback
- Inherits the serif drop cap added in #11

## Test plan
- [ ] Visit /notes/inside-context-outside-eyes and confirm it renders with the drop cap
- [ ] Visit /notes and confirm it lists under 2026 above the Figma note
- [ ] Confirm #process and #feedback tag pages resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)