### PR TITLE
Home redesign: "Peel" cover + Figma workspace, dark-blue palette

### DIFF
--- a/src/layouts/CaseStudyLayout.astro
+++ b/src/layouts/CaseStudyLayout.astro
@@ -18,7 +18,7 @@ const { title, description, image } = Astro.props;
 
 <style is:global>
   body {
-    background: #1a1a1a;
+    background: #102237;
     color: #ffffff;
     font-family: 'NB International', -apple-system, BlinkMacSystemFont, 'SF Pro Display', 'Inter', sans-serif;
     font-weight: 300;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,24 +2,12 @@
 import { getPublishedNotes } from '../lib/notes';
 import { selectedWork, contact } from '../lib/work';
 
-// Notes seam — live from the notes content collection.
+// Notes seam — latest post from the notes content collection.
 const notes = await getPublishedNotes();
-const recentNotes = notes.slice(0, 5);
 const latestNote = notes[0];
 
-// ⌘K command items. The "Work" group derives from the same selectedWork source
-// as the hero column, so the palette and the visible list never drift.
-type CmdItem = { label: string; group: string; kind: 'nav' | 'link' | 'copy'; value: string };
-const commandItems: CmdItem[] = [
-  { label: 'About', group: 'Navigate', kind: 'nav', value: 'about' },
-  { label: 'Work', group: 'Navigate', kind: 'nav', value: 'work' },
-  { label: 'Notes', group: 'Navigate', kind: 'nav', value: 'notes' },
-  { label: 'Contact', group: 'Navigate', kind: 'nav', value: 'contact' },
-  ...selectedWork.map((w): CmdItem => ({ label: w.name, group: 'Work', kind: 'link', value: w.url })),
-  { label: 'Copy email', group: 'Action', kind: 'copy', value: contact.email },
-  { label: 'Bluesky', group: 'Link', kind: 'link', value: contact.bluesky.url },
-  { label: 'GitHub', group: 'Link', kind: 'link', value: contact.github.url },
-];
+// dynatrace.com link in the cover intro line.
+const DYNATRACE_URL = 'https://www.dynatrace.com';
 ---
 
 <!doctype html>
@@ -30,7 +18,6 @@ const commandItems: CmdItem[] = [
   <title>Nilson Gaspar — Product Designer</title>
   <meta name="description" content="Nilson Gaspar — product designer working in developer tools and observability. Currently at Dynatrace, previously Grafana Labs. Based in Lisbon." />
   <meta name="author" content="Nilson Gaspar" />
-  <meta name="view-transition" content="same-origin" />
 
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://nilsongaspar.com/" />
@@ -43,574 +30,598 @@ const commandItems: CmdItem[] = [
 
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500&display=swap" />
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&display=swap" />
 
   <!-- Umami Analytics -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="17a602b8-56cc-4328-83d4-0f16fefc8fd9"></script>
 
   <style>
     :root {
-      --bg: #161513;
-      --surface-field: #1d1b16;
-      --surface-drop: #1e1c17;
-      --surface-sheet: #1a1916;
-      --surface-chip: #26241e;
-      --primary: #eceae2;
-      --secondary: #c9c6bc;
-      --tertiary: #a8a59b;
-      --muted: #8a877c;
-      --muted-2: #9a978c;
-      --faint: #6f6c63;
-      --rule: #2c2922;
-      --rule-soft: #262219;
-      --rule-field: #2f2c25;
-      --rule-drop: #34312a;
-      --rule-chip: #3a372f;
-      --accent: #8fe3b0;
+      --accent: #54E0A6;
       --sans: 'Helvetica Neue', Helvetica, Arial, 'Segoe UI', sans-serif;
-      --mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+      --mono: 'IBM Plex Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
     }
-
     * { box-sizing: border-box; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }
-    html, body { margin: 0; height: 100%; background: var(--bg); }
-    body { color: var(--primary); font-family: var(--sans); }
+    html, body { margin: 0; height: 100%; background: #102237; overflow: hidden; }
     a { color: inherit; text-decoration: none; }
-    input { font-family: inherit; }
-    ::placeholder { color: var(--faint); }
-    ::selection { background: #3a372f; color: #fff; }
 
-    @keyframes sigPulse { 0%, 100% { transform: scale(1); opacity: 1; } 50% { transform: scale(.6); opacity: .5; } }
-    @keyframes sigRing { 0% { transform: scale(1); opacity: .5; } 70% { transform: scale(3.2); opacity: 0; } 100% { opacity: 0; } }
-    @keyframes hintGlow { 0%, 100% { border-color: var(--rule-field); box-shadow: 0 0 0 0 rgba(236, 234, 226, 0); } 50% { border-color: #6b6557; box-shadow: 0 0 0 4px rgba(236, 234, 226, .09); } }
+    @keyframes hintPulse { 0%, 100% { opacity: .22; transform: translate(0, 0); } 50% { opacity: .55; transform: translate(-2px, 2px); } }
+    @keyframes curA { 0% { transform: translate(380px, 240px); } 25% { transform: translate(600px, 150px); } 50% { transform: translate(660px, 470px); } 75% { transform: translate(430px, 520px); } 100% { transform: translate(380px, 240px); } }
+    @keyframes curB { 0% { transform: translate(940px, 170px); } 33% { transform: translate(1120px, 440px); } 66% { transform: translate(790px, 600px); } 100% { transform: translate(940px, 170px); } }
+    @keyframes commentPulse { 0% { transform: scale(1); opacity: .55; } 70% { transform: scale(2.6); opacity: 0; } 100% { opacity: 0; } }
 
-    .page {
-      position: relative;
-      min-height: 100%;
-      display: flex;
-      flex-direction: column;
-      padding: clamp(26px, 4.5vw, 56px);
+    /* cover link hovers → accent */
+    [data-cover-nav] a:hover, .cover-footer a:hover { color: var(--accent); }
+    .dyn-link:hover { color: var(--accent) !important; }
+    /* chrome icon hovers */
+    .icon-btn:hover { background: #20395A; }
+    .back-btn:hover { background: #20395A; color: #fff; }
+
+    /* tablet: drop the properties (right) panel, no room */
+    @media (max-width: 1024px) { [data-panel="right"] { display: none !important; } }
+    /* mobile: drop the IDE chrome, canvas + top bar only */
+    @media (max-width: 760px) {
+      [data-panel="left"] { display: none !important; }
+      [data-panel="toolbar"] { display: none !important; }
+      [data-topbar] { padding-left: 14px !important; }
     }
-
-    /* ---------- top bar ---------- */
-    .topbar { display: flex; align-items: center; justify-content: space-between; gap: 16px; flex-wrap: wrap; }
-    .identity { display: flex; align-items: baseline; gap: 12px; }
-    .identity__name { font-size: 15px; font-weight: 500; letter-spacing: -.01em; color: var(--primary); }
-    .identity__role { font-family: var(--mono); font-size: 11px; letter-spacing: .04em; color: var(--muted); }
-
-    .search { position: relative; z-index: 50; }
-    .search__field {
-      display: flex; align-items: center; justify-content: space-between; gap: 12px;
-      min-width: clamp(200px, 28vw, 320px);
-      background: var(--surface-field); border: 1px solid var(--rule-field); border-radius: 9px;
-      padding: 10px 11px 10px 14px; color: var(--muted-2);
-      animation: hintGlow 2.8s ease-in-out 1s 3;
+    /* cover: stack the right nav under the headline on narrow screens */
+    @media (max-width: 720px) {
+      [data-cover-row] { flex-direction: column !important; align-items: flex-start !important; gap: 40px !important; }
+      [data-cover-nav] { align-items: flex-start !important; text-align: left !important; margin-left: 0 !important; max-width: 100% !important; width: 100%; }
+      [data-cover-nav] a { align-items: flex-start !important; }
+      [data-cover-nav] > div { align-items: flex-start !important; }
+      [data-cover-divider] { width: 100% !important; }
     }
-    .search__group { display: flex; align-items: center; gap: 9px; flex: 1; min-width: 0; }
-    .search__group svg { flex: none; }
-    .search__input { flex: 1; min-width: 0; background: transparent; border: none; outline: none; color: var(--primary); font-size: 13px; }
-    .keys { display: flex; gap: 3px; flex: none; }
-    .key { font-family: var(--mono); font-size: 11px; background: var(--surface-chip); border: 1px solid var(--rule-chip); border-radius: 4px; padding: 1px 5px; }
-
-    /* ---------- command palette ---------- */
-    .palette {
-      position: absolute; top: calc(100% + 8px); right: 0; width: min(440px, 86vw);
-      background: var(--surface-drop); border: 1px solid var(--rule-drop); border-radius: 12px;
-      box-shadow: 0 24px 60px rgba(0, 0, 0, .55); overflow: hidden;
-      opacity: 0; transform: translateY(-6px); pointer-events: none;
-      transition: opacity .16s ease, transform .16s ease;
-    }
-    .palette.is-open { opacity: 1; transform: translateY(0); pointer-events: auto; }
-    .palette__list { max-height: min(58vh, 430px); overflow: auto; }
-    .palette__foot {
-      display: flex; align-items: center; gap: 16px; padding: 10px 16px;
-      border-top: 1px solid var(--rule); font-family: var(--mono); font-size: 11px; color: var(--faint);
-    }
-
-    .cmd-row {
-      position: relative; display: flex; align-items: center; justify-content: space-between; gap: 12px;
-      width: 100%; padding: 13px 18px; cursor: pointer; text-align: left;
-      background: transparent; border: none; border-top: 1px solid var(--rule-soft); color: var(--primary);
-    }
-    .cmd-row:first-child { border-top-color: transparent; }
-    .cmd-row[hidden] { display: none; }
-    .cmd-row:hover { background: #211f18; }
-    .cmd-row.is-active { background: #221f18; }
-    .cmd-bar { position: absolute; left: 0; top: 0; bottom: 0; width: 2px; background: transparent; }
-    .cmd-row.is-active .cmd-bar { background: var(--accent); }
-    .cmd-left { display: flex; align-items: center; gap: 11px; min-width: 0; }
-    .cmd-dot { width: 6px; height: 6px; border-radius: 50%; flex: none; background: var(--accent); }
-    .cmd-dot.is-faint { background: var(--faint); }
-    .cmd-label { font-size: 14px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-    .cmd-group { font-family: var(--mono); font-size: 10px; letter-spacing: .06em; text-transform: uppercase; color: var(--faint); flex: none; }
-    .palette__empty { padding: 22px 16px; text-align: center; color: var(--faint); font-size: 13px; }
-    .palette__empty[hidden] { display: none; }
-
-    /* ---------- hero ---------- */
-    .hero { flex: 1; display: flex; align-items: center; justify-content: space-between; gap: clamp(32px, 6vw, 90px); flex-wrap: wrap; padding: 36px 0; }
-    .hero__left { max-width: clamp(340px, 53vw, 800px); min-width: 280px; }
-    .hero__title { margin: 0; font-weight: 500; font-size: clamp(2.4rem, min(6.4vw, 11vh), 5.9rem); line-height: 1.02; letter-spacing: -.032em; }
-    .currently { margin-top: 36px; max-width: 500px; }
-    .currently__rule { height: 1px; background: var(--rule-drop); }
-    .currently__kickers { margin-top: 13px; display: flex; align-items: baseline; justify-content: space-between; gap: 16px; font-family: var(--mono); font-size: 11px; letter-spacing: .16em; text-transform: uppercase; color: var(--faint); }
-    .currently__kickers .lead { color: var(--primary); }
-    .currently__statement { margin-top: 12px; font-size: clamp(18px, 2.1vw, 27px); line-height: 1.28; letter-spacing: -.015em; color: var(--secondary); font-weight: 400; }
-    .currently__statement em { font-style: italic; font-weight: 500; color: var(--primary); }
-
-    .work-nav { display: flex; flex-direction: column; align-items: flex-end; gap: clamp(14px, 2.2vh, 24px); flex: none; max-width: 340px; }
-    .work-nav__kicker { font-family: var(--mono); font-size: 11px; letter-spacing: .2em; text-transform: uppercase; color: var(--faint); }
-    .work-nav__sep { align-self: stretch; height: 1px; background: var(--rule-drop); margin: clamp(4px, 1vh, 10px) 0; }
-    .work-link { display: flex; flex-direction: column; align-items: flex-end; gap: 4px; text-align: right; color: var(--primary); transition: color .2s ease; background: none; border: none; padding: 0; cursor: pointer; font: inherit; }
-    .work-link:hover { color: #fff; }
-    .work-link__name { font-size: clamp(1.3rem, 2.5vw, 2rem); font-weight: 400; letter-spacing: -.018em; display: inline-flex; align-items: center; gap: 7px; }
-    .work-link__name svg { flex: none; opacity: .8; }
-    .work-link__cap { font-family: var(--mono); font-size: 11px; color: var(--faint); }
-
-    /* ---------- footer ---------- */
-    .footer { display: flex; align-items: flex-end; justify-content: space-between; gap: 20px; flex-wrap: wrap; }
-    .footer__left { display: flex; flex-direction: column; gap: 7px; }
-    .footer__hint { text-align: left; background: none; border: none; padding: 0; cursor: pointer; color: var(--muted-2); font-size: 12px; font-family: var(--mono); letter-spacing: .02em; transition: color .2s ease; }
-    .footer__hint:hover { color: var(--primary); }
-    .footer__hint .key { color: inherit; }
-    .live { display: flex; align-items: center; gap: 9px; font-family: var(--mono); font-size: 12px; color: var(--faint); flex-wrap: wrap; }
-    .live__dot { position: relative; width: 7px; height: 7px; flex: none; }
-    .live__dot span { position: absolute; inset: 0; border-radius: 50%; background: var(--accent); }
-    .live__dot .ring { animation: sigRing 2.6s ease-out infinite; }
-    .live__dot .core { animation: sigPulse 2.6s ease-in-out infinite; }
-    .live__clock { color: var(--muted); }
-    .footer__links { display: flex; gap: 18px; align-items: center; font-size: 12px; letter-spacing: .08em; text-transform: uppercase; color: var(--faint); }
-    .footer__links a, .footer__links button { color: var(--faint); background: none; border: none; padding: 0; cursor: pointer; font: inherit; letter-spacing: inherit; text-transform: inherit; transition: color .2s ease; }
-    .footer__links a:hover, .footer__links button:hover { color: var(--primary); }
-
-    /* ---------- click catcher (palette outside-click) ---------- */
-    .catcher { position: fixed; inset: 0; z-index: 44; background: transparent; pointer-events: none; }
-    .catcher.is-open { pointer-events: auto; }
-
-    /* ---------- slide-over ---------- */
-    .scrim { position: fixed; inset: 0; z-index: 39; background: rgba(8, 8, 6, .5); opacity: 0; pointer-events: none; transition: opacity .33s cubic-bezier(.22, 1, .36, 1); }
-    .scrim.is-open { opacity: 1; pointer-events: auto; }
-    .drawer {
-      position: fixed; top: 0; right: 0; bottom: 0; width: min(640px, 92vw); z-index: 40;
-      background: var(--surface-sheet); border-left: 1px solid var(--rule); box-shadow: -24px 0 70px rgba(0, 0, 0, .5);
-      overflow-y: auto; overflow-x: hidden;
-      transform: translateX(100%); pointer-events: none;
-      transition: transform .33s cubic-bezier(.22, 1, .36, 1);
-    }
-    .drawer.is-open { transform: translateX(0); pointer-events: auto; }
-    .sheet { min-height: 100%; padding: clamp(28px, 4vw, 52px); }
-    .sheet__chrome { display: flex; align-items: center; justify-content: space-between; gap: 20px; margin-bottom: clamp(46px, 8vh, 96px); }
-    .sheet__kicker { display: flex; align-items: baseline; gap: 10px; font-family: var(--mono); font-size: 11px; letter-spacing: .16em; text-transform: uppercase; color: var(--faint); }
-    .sheet__kicker .lead { color: var(--primary); }
-    .sheet__close { display: flex; align-items: center; gap: 8px; background: none; border: none; cursor: pointer; color: var(--muted-2); font-family: var(--mono); font-size: 11px; letter-spacing: .12em; text-transform: uppercase; padding: 6px 2px; transition: color .2s ease; }
-    .sheet__close:hover { color: var(--primary); }
-
-    .sheet-view { display: none; }
-    .sheet-view.is-active { display: block; }
-
-    /* About */
-    .about__standfirst { margin: 0; max-width: 18ch; font-weight: 500; font-size: clamp(2rem, 4.6vw, 3.7rem); line-height: 1.08; letter-spacing: -.03em; color: var(--primary); }
-    .about__cols { display: flex; gap: clamp(36px, 6vw, 100px); flex-wrap: wrap; margin-top: clamp(46px, 7vh, 84px); }
-    .about__meta { flex: 0 0 200px; display: flex; flex-direction: column; font-family: var(--mono); }
-    .meta-row { display: flex; flex-direction: column; gap: 5px; padding: 14px 0; border-top: 1px solid var(--rule); }
-    .about__meta .meta-row:last-child { border-bottom: 1px solid var(--rule); }
-    .meta-row__label { font-size: 10px; letter-spacing: .16em; text-transform: uppercase; color: var(--faint); }
-    .meta-row__value { font-size: 13px; color: var(--secondary); }
-    .about__body { flex: 1 1 460px; max-width: 60ch; }
-    .about__lead { margin: 0; font-size: clamp(16px, 1.5vw, 19px); line-height: 1.6; color: var(--secondary); }
-    .about__lead + .about__lead { margin-top: 22px; font-size: clamp(15px, 1.4vw, 17px); line-height: 1.65; color: var(--tertiary); }
-    .pull { margin: clamp(38px, 5vh, 58px) 0; padding-top: 22px; border-top: 1px solid var(--rule); }
-    .pull__kicker { font-family: var(--mono); font-size: 10px; letter-spacing: .18em; text-transform: uppercase; color: var(--faint); margin-bottom: 16px; }
-    .pull__quote { margin: 0; font-size: clamp(1.5rem, 3vw, 2.2rem); line-height: 1.26; letter-spacing: -.02em; color: var(--primary); font-weight: 400; }
-    .pull__quote em { font-style: italic; }
-    .principles { display: flex; flex-direction: column; }
-    .principle { display: flex; gap: 20px; padding: 20px 0; border-top: 1px solid var(--rule); }
-    .principles .principle:last-child { border-bottom: 1px solid var(--rule); }
-    .principle__num { font-family: var(--mono); font-size: 12px; color: var(--faint); flex: none; padding-top: 3px; }
-    .principle__title { font-size: 16px; color: var(--primary); margin-bottom: 6px; }
-    .principle__desc { font-size: 14px; line-height: 1.55; color: var(--muted); }
-
-    /* ruled rows (Work / Notes / Contact) */
-    .rows { display: flex; flex-direction: column; max-width: 780px; }
-    .rows .row:last-child { border-bottom: 1px solid var(--rule); }
-    .row { display: flex; align-items: baseline; justify-content: space-between; gap: 16px; padding: 20px 0; border-top: 1px solid var(--rule); color: inherit; }
-    a.row { transition: color .2s ease; }
-    a.row:hover { color: #fff; }
-    .row__title { font-size: 18px; font-weight: 500; }
-    .row__desc { font-size: 14px; color: var(--muted); margin-top: 4px; }
-    .row__tag { font-family: var(--mono); font-size: 11px; color: var(--faint); flex: none; }
-    .row__tag.is-now { color: var(--secondary); }
-
-    .sheet__lead { margin: 0 0 28px; font-size: clamp(16px, 1.5vw, 19px); line-height: 1.6; color: var(--secondary); max-width: 46ch; }
-    .notes-more { display: inline-block; margin-top: 28px; font-family: var(--mono); font-size: 12px; letter-spacing: .08em; text-transform: uppercase; color: var(--faint); transition: color .2s ease; }
-    .notes-more:hover { color: var(--primary); }
-    .note-row { padding: 18px 0; }
-    .note-row .row__year { font-family: var(--mono); font-size: 11px; color: var(--faint); flex: none; }
-    .note-row .row__title { font-size: 17px; font-weight: 400; }
-
-    .contact-row { align-items: center; }
-    .contact-row__label { color: var(--muted); font-size: 13px; font-family: var(--mono); letter-spacing: .1em; text-transform: uppercase; }
-    .contact-row__value { font-family: var(--mono); font-size: 15px; }
-
-    /* ---------- toast ---------- */
-    .toast {
-      position: fixed; bottom: 30px; left: 50%; z-index: 60; transform: translateX(-50%);
-      background: var(--surface-chip); border: 1px solid var(--rule-chip); border-radius: 9px;
-      padding: 9px 16px; font-family: var(--mono); font-size: 12px; color: var(--primary);
-      opacity: 0; pointer-events: none; box-shadow: 0 10px 30px rgba(0, 0, 0, .5);
-      transition: opacity .2s ease;
-    }
-    .toast.is-visible { opacity: 1; }
 
     @media (prefers-reduced-motion: reduce) {
-      .search__field { animation: none; }
-      .live__dot .ring, .live__dot .core { animation: none; }
-      .palette, .scrim, .drawer, .toast { transition: none; }
+      [data-hint], [data-cur], [data-comment] > div:first-child { animation: none !important; }
     }
   </style>
 </head>
 <body>
-  <div class="page">
+<div data-stage style="position:fixed; inset:0; overflow:hidden; font-family:var(--sans);">
+
+  <!-- ===================================================== -->
+  <!-- ===== Workspace: the "About" as a design canvas ===== -->
+  <!-- ===================================================== -->
+  <div data-about style="position:absolute; inset:0; z-index:1; background:#122541; color:#fff; overflow:hidden; pointer-events:none;">
+
+    <!-- canvas -->
+    <div data-canvasbg style="position:absolute; inset:0; z-index:1; background:#122541; background-image:radial-gradient(circle, rgba(255,255,255,.045) 1px, transparent 1.4px); background-size:28px 28px; cursor:grab;">
+      <div data-group style="position:absolute; left:0; top:0; will-change:transform;">
+
+        <!-- layout guides -->
+        <div style="position:absolute; left:80px; top:-200px; width:1px; height:1500px; background:rgba(255,61,119,.35);"></div>
+        <div style="position:absolute; left:600px; top:-200px; width:1px; height:1500px; background:rgba(255,61,119,.22);"></div>
+        <div style="position:absolute; left:600px; top:130px; width:80px; height:0; border-top:1px dashed #ff3d77;"></div>
+        <div style="position:absolute; left:626px; top:118px; background:#ff3d77; color:#fff; font-size:10px; padding:1px 5px; border-radius:2px; font-family:var(--mono);">80</div>
+
+        <!-- FRAME: About -->
+        <div data-frame="about" style="position:absolute; left:80px; top:70px; width:520px; height:580px; background:#182E49; border:1px solid #2C476A; cursor:pointer;">
+          <div data-framelabel="about" style="position:absolute; top:-22px; left:0; font-size:11px; color:var(--accent); white-space:nowrap;">About</div>
+          <div style="padding:36px;">
+            <div style="font-family:var(--mono); font-size:11px; letter-spacing:.16em; text-transform:uppercase; color:var(--accent);">About / 01</div>
+            <h2 style="margin:18px 0 0; font-weight:500; font-size:56px; line-height:.9; letter-spacing:-.035em;">Nilson<br>Gaspar</h2>
+            <p style="margin:24px 0 0; font-size:16px; line-height:1.5; color:#C2C9D4;">I'm a product designer specializing in developer tools and observability platforms. My broad design background helps me create technical products that feel surprisingly human.</p>
+            <blockquote style="margin:28px 0 0; padding-left:16px; border-left:2px solid var(--accent); font-style:italic; font-size:17px; line-height:1.4; color:#E7EAF0;">There's nothing quite like making a developer say "finally, this makes sense!"</blockquote>
+          </div>
+        </div>
+
+        <!-- FRAME: Why -->
+        <div data-frame="why" style="position:absolute; left:680px; top:70px; width:480px; height:420px; background:#182E49; border:1px solid #2C476A; cursor:pointer;">
+          <div data-framelabel="why" style="position:absolute; top:-22px; left:0; font-size:11px; color:#8B94A3; white-space:nowrap;">Why</div>
+          <div style="padding:30px;">
+            <div style="font-family:var(--mono); font-size:11px; letter-spacing:.16em; text-transform:uppercase; color:#8B94A3;">Why / 02</div>
+            <h3 style="margin:14px 0 0; font-weight:500; font-size:30px; letter-spacing:-.02em; line-height:1.05;">Technical products.</h3>
+            <p style="margin:16px 0 0; font-size:14px; line-height:1.55; color:#9AA3B0;">Complex problems energize me. Transforming observability data into actionable insights at Grafana taught me that the harder the technical challenge, the more impactful good design becomes.</p>
+            <div style="margin-top:26px; padding-top:22px; border-top:1px solid #2C476A;">
+              <div style="font-family:var(--mono); font-size:10px; letter-spacing:.12em; text-transform:uppercase; color:#525B69;">time-to-insight</div>
+              <div style="font-size:50px; font-weight:600; letter-spacing:-.04em; color:var(--accent); line-height:1; margin-top:4px;">−20%</div>
+              <div style="font-size:13px; color:#9AA3B0; margin-top:8px; line-height:1.45;">on Grafana's APM tools — thousands of engineers finding and fixing issues faster.</div>
+            </div>
+          </div>
+        </div>
+
+        <!-- FRAME: Principles -->
+        <div data-frame="principles" style="position:absolute; left:680px; top:540px; width:620px; height:280px; background:#182E49; border:1px solid #2C476A; cursor:pointer;">
+          <div data-framelabel="principles" style="position:absolute; top:-22px; left:0; font-size:11px; color:#8B94A3; white-space:nowrap;">Principles</div>
+          <div style="padding:28px 30px;">
+            <div style="font-family:var(--mono); font-size:11px; letter-spacing:.16em; text-transform:uppercase; color:#8B94A3; margin-bottom:20px;">Principles / 03</div>
+            <div style="display:flex; gap:28px;">
+              <div style="flex:1;">
+                <div style="font-family:var(--mono); font-size:12px; color:var(--accent); margin-bottom:10px;">01</div>
+                <h4 style="margin:0 0 8px; font-weight:500; font-size:15px;">Real-time impact at scale</h4>
+                <p style="margin:0; font-size:12.5px; line-height:1.5; color:#9AA3B0;">When the work ships, it's not a mock — it's thousands of engineers moving faster every day.</p>
+              </div>
+              <div style="flex:1;">
+                <div style="font-family:var(--mono); font-size:12px; color:var(--accent); margin-bottom:10px;">02</div>
+                <h4 style="margin:0 0 8px; font-weight:500; font-size:15px;">Collaboration with brilliant minds</h4>
+                <p style="margin:0; font-size:12.5px; line-height:1.5; color:#9AA3B0;">Working with engineers sharpened how I think. I ask "what's possible?" before "what's ideal?"</p>
+              </div>
+              <div style="flex:1;">
+                <div style="font-family:var(--mono); font-size:12px; color:var(--accent); margin-bottom:10px;">03</div>
+                <h4 style="margin:0 0 8px; font-weight:500; font-size:15px;">Art and science</h4>
+                <p style="margin:0; font-size:12.5px; line-height:1.5; color:#9AA3B0;">Visualizing millions of data points needs both aesthetic sense and a deep grasp of how developers work.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- FRAME: Homepage (mini) -->
+        <div data-frame="home" style="position:absolute; left:80px; top:700px; width:380px; height:230px; background:#102237; border:1px solid #2C476A; cursor:pointer; overflow:hidden;">
+          <div data-framelabel="home" style="position:absolute; top:-22px; left:0; font-size:11px; color:#8B94A3; white-space:nowrap;">Homepage</div>
+          <div style="padding:24px; height:100%; display:flex; flex-direction:column; justify-content:space-between;">
+            <div style="font-weight:500; font-size:23px; line-height:1.02; letter-spacing:-.02em; color:#E7EAF0;">I make complex developer tools feel a little more <span style="text-decoration:underline; text-decoration-color:#54E0A6;">human</span>.</div>
+            <div style="font-family:var(--mono); font-size:9px; letter-spacing:.05em; color:#8B94A3;">38.6892603333238</div>
+          </div>
+        </div>
+
+        <!-- FRAME: Sitemap (decorative IA — not wired to routing) -->
+        <div data-frame="ia" style="position:absolute; left:700px; top:880px; width:720px; height:580px; background:#182E49; border:1px solid #2C476A; cursor:pointer;">
+          <div data-framelabel="ia" style="position:absolute; top:-22px; left:0; font-size:11px; color:#8B94A3; white-space:nowrap;">Sitemap</div>
+          <div style="padding:28px 32px;">
+            <div style="font-family:var(--mono); font-size:11px; letter-spacing:.16em; text-transform:uppercase; color:#8B94A3;">Information architecture / 04</div>
+            <div style="position:relative; width:656px; height:470px; margin-top:18px;">
+              <svg width="540" height="470" viewBox="0 0 540 470" fill="none" style="position:absolute; left:0; top:0; overflow:visible;">
+                <defs><marker id="jamArrow" markerWidth="7" markerHeight="7" refX="5" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="#5A6473"></path></marker></defs>
+                <path d="M130 236 C158 236 150 56 176 56" stroke="#5A6473" stroke-width="2" marker-end="url(#jamArrow)"></path>
+                <path d="M130 236 C158 236 150 176 176 176" stroke="#5A6473" stroke-width="2" marker-end="url(#jamArrow)"></path>
+                <path d="M130 236 C158 236 150 296 176 296" stroke="#5A6473" stroke-width="2" marker-end="url(#jamArrow)"></path>
+                <path d="M130 236 C158 236 150 416 176 416" stroke="#5A6473" stroke-width="2" marker-end="url(#jamArrow)"></path>
+                <path d="M310 296 C346 296 348 229 376 229" stroke="#5A6473" stroke-width="2" marker-end="url(#jamArrow)"></path>
+                <path d="M310 296 C346 296 348 297 376 297" stroke="#5A6473" stroke-width="2" marker-end="url(#jamArrow)"></path>
+                <path d="M310 296 C346 296 348 365 376 365" stroke="#5A6473" stroke-width="2" marker-end="url(#jamArrow)"></path>
+                <path d="M310 296 C346 296 348 433 376 433" stroke="#5A6473" stroke-width="2" marker-end="url(#jamArrow)"></path>
+              </svg>
+              <div style="position:absolute; left:0; top:190px; width:130px; height:92px; padding:12px 13px; box-sizing:border-box; background:#6FB6FF; border-radius:3px; box-shadow:0 7px 16px rgba(0,0,0,.42); transform:rotate(-2deg); display:flex; flex-direction:column; justify-content:center; color:#08243f;">
+                <span style="font-size:15px; font-weight:600;">Root</span>
+                <span style="font-family:var(--mono); font-size:9px; margin-top:4px; opacity:.7;">nilsongaspar.omg.lol</span>
+              </div>
+              <div style="position:absolute; left:180px; top:10px; width:130px; height:92px; padding:12px 13px; box-sizing:border-box; background:#FFD84D; border-radius:3px; box-shadow:0 7px 16px rgba(0,0,0,.42); transform:rotate(1.5deg); display:flex; flex-direction:column; justify-content:center; color:#2a2410;">
+                <span style="font-size:15px; font-weight:600;">Cover</span><span style="font-size:11px; opacity:.62; margin-top:3px;">the calm face</span>
+              </div>
+              <div style="position:absolute; left:180px; top:130px; width:130px; height:92px; padding:12px 13px; box-sizing:border-box; background:#FFD84D; border-radius:3px; box-shadow:0 7px 16px rgba(0,0,0,.42); transform:rotate(-1deg); display:flex; flex-direction:column; justify-content:center; color:#2a2410;">
+                <span style="font-size:15px; font-weight:600;">About</span><span style="font-size:11px; opacity:.62; margin-top:3px;">behind the peel</span>
+                <span style="position:absolute; bottom:7px; right:8px; width:16px; height:16px; border-radius:50%; background:#1abc9c; color:#053; font-size:9px; font-weight:700; display:flex; align-items:center; justify-content:center;">A</span>
+              </div>
+              <div style="position:absolute; left:180px; top:250px; width:130px; height:92px; padding:12px 13px; box-sizing:border-box; background:#FFD84D; border-radius:3px; box-shadow:0 7px 16px rgba(0,0,0,.42); transform:rotate(2deg); display:flex; flex-direction:column; justify-content:center; color:#2a2410;">
+                <span style="font-size:15px; font-weight:600;">Work</span><span style="font-size:11px; opacity:.62; margin-top:3px;">4 projects</span>
+                <span style="position:absolute; bottom:-9px; right:-7px; background:#fff; border-radius:11px; padding:2px 7px 2px 6px; font-size:11px; box-shadow:0 2px 6px rgba(0,0,0,.3); color:#2C476A;">❤️ 3</span>
+              </div>
+              <div style="position:absolute; left:180px; top:370px; width:130px; height:92px; padding:12px 13px; box-sizing:border-box; background:#FFD84D; border-radius:3px; box-shadow:0 7px 16px rgba(0,0,0,.42); transform:rotate(-1.5deg); display:flex; flex-direction:column; justify-content:center; color:#2a2410;">
+                <span style="font-size:15px; font-weight:600;">Notes</span><span style="font-size:11px; opacity:.62; margin-top:3px;">writing</span>
+              </div>
+              <div style="position:absolute; left:380px; top:200px; width:140px; height:58px; padding:10px 12px; box-sizing:border-box; background:#A7E0A0; border-radius:3px; box-shadow:0 6px 13px rgba(0,0,0,.4); transform:rotate(-2deg); display:flex; align-items:center; font-size:13px; font-weight:600; color:#1e2a14;">Keystrok</div>
+              <div style="position:absolute; left:380px; top:268px; width:140px; height:58px; padding:10px 12px; box-sizing:border-box; background:#FFB3CE; border-radius:3px; box-shadow:0 6px 13px rgba(0,0,0,.4); transform:rotate(1.5deg); display:flex; align-items:center; font-size:13px; font-weight:600; color:#3a1424;">Open source</div>
+              <div style="position:absolute; left:380px; top:336px; width:140px; height:58px; padding:10px 12px; box-sizing:border-box; background:#FFC078; border-radius:3px; box-shadow:0 6px 13px rgba(0,0,0,.4); transform:rotate(-1deg); display:flex; align-items:center; font-size:13px; font-weight:600; color:#3a2410;">Grafana Labs</div>
+              <div style="position:absolute; left:380px; top:404px; width:140px; height:58px; padding:10px 12px; box-sizing:border-box; background:#BBD9FF; border-radius:3px; box-shadow:0 6px 13px rgba(0,0,0,.4); transform:rotate(2deg); display:flex; align-items:center; justify-content:space-between; font-size:13px; font-weight:600; color:#0a2540;">Dynatrace <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="#0a2540" stroke-width="2.4"><rect x="5" y="11" width="14" height="9" rx="1.5"></rect><path d="M8 11V7a4 4 0 0 1 8 0v4"></path></svg></div>
+            </div>
+          </div>
+        </div>
+
+        <!-- collaborator cursors -->
+        <div data-cur style="position:absolute; left:0; top:0; pointer-events:none; z-index:6; animation:curA 26s ease-in-out infinite;">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="#1abc9c" style="filter:drop-shadow(0 1px 2px rgba(0,0,0,.5));"><path d="M5 2l15 8-6.5 1.6L10 21z"></path></svg>
+          <div style="margin:1px 0 0 12px; background:#1abc9c; color:#073; font-size:10px; font-weight:600; padding:2px 7px; border-radius:8px; white-space:nowrap;">Ana</div>
+        </div>
+        <div data-cur style="position:absolute; left:0; top:0; pointer-events:none; z-index:6; animation:curB 32s ease-in-out infinite;">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="#b07cff" style="filter:drop-shadow(0 1px 2px rgba(0,0,0,.5));"><path d="M5 2l15 8-6.5 1.6L10 21z"></path></svg>
+          <div style="margin:1px 0 0 12px; background:#b07cff; color:#2a0a4a; font-size:10px; font-weight:600; padding:2px 7px; border-radius:8px; white-space:nowrap;">Theo</div>
+        </div>
+
+        <!-- comment pin -->
+        <div data-comment style="position:absolute; left:470px; top:520px; pointer-events:none; z-index:6;">
+          <div style="position:absolute; left:0; top:0; width:30px; height:30px; border-radius:50%; background:#ff7a59; animation:commentPulse 2.8s ease-out infinite;"></div>
+          <div style="position:relative; width:30px; height:30px; border-radius:50% 50% 50% 3px; background:#fff; box-shadow:0 2px 8px rgba(0,0,0,.45); display:flex; align-items:center; justify-content:center; color:#ff7a59; font-size:12px; font-weight:700;">N</div>
+        </div>
+
+        <!-- selection overlay -->
+        <div data-sel style="position:absolute; left:80px; top:70px; width:520px; height:580px; border:1.5px solid var(--accent); pointer-events:none; z-index:7;">
+          <span style="position:absolute; left:-4px; top:-4px; width:7px; height:7px; background:#fff; border:1px solid var(--accent); border-radius:1px;"></span>
+          <span style="position:absolute; right:-4px; top:-4px; width:7px; height:7px; background:#fff; border:1px solid var(--accent); border-radius:1px;"></span>
+          <span style="position:absolute; left:-4px; bottom:-4px; width:7px; height:7px; background:#fff; border:1px solid var(--accent); border-radius:1px;"></span>
+          <span style="position:absolute; right:-4px; bottom:-4px; width:7px; height:7px; background:#fff; border:1px solid var(--accent); border-radius:1px;"></span>
+          <div data-seldim style="position:absolute; left:50%; bottom:-24px; transform:translateX(-50%); background:var(--accent); color:#102237; font-size:10px; padding:1px 6px; border-radius:2px; white-space:nowrap; font-family:var(--mono);">520 × 580</div>
+        </div>
+
+      </div>
+    </div>
 
     <!-- top bar -->
-    <div class="topbar">
-      <div class="identity">
-        <span class="identity__name">Nilson Gaspar</span>
-        <span class="identity__role">product designer</span>
+    <div data-topbar style="position:absolute; top:0; left:0; right:0; height:46px; background:#16304C; border-bottom:1px solid #0A1626; display:flex; align-items:center; justify-content:space-between; padding:0 12px 0 134px; z-index:5; font-size:12px; color:#8B94A3;">
+      <div style="display:flex; align-items:center; gap:9px;">
+        <span style="color:#fff;">Nilson Gaspar</span>
+        <svg width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="#5A6473" stroke-width="2.4"><path d="M6 9l6 6 6-6"></path></svg>
+        <span style="color:#3D4452;">/</span>
+        <span style="color:#C2C9D4;">About</span>
       </div>
-
-      <div class="search">
-        <div class="search__field" id="searchField">
-          <span class="search__group">
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="10" cy="10" r="6"></circle><path d="M20 20l-5-5"></path></svg>
-            <input class="search__input" id="searchInput" type="text" placeholder="Search or jump to…" aria-label="Search or jump to a section" autocomplete="off" spellcheck="false" />
-          </span>
-          <span class="keys"><span class="key">⌘</span><span class="key">K</span></span>
+      <div style="display:flex; align-items:center; gap:12px;">
+        <div style="display:flex;">
+          <span style="width:24px; height:24px; border-radius:50%; background:#1abc9c; color:#053; font-size:10px; font-weight:700; display:flex; align-items:center; justify-content:center; border:2px solid #16304C;">A</span>
+          <span style="width:24px; height:24px; border-radius:50%; background:#b07cff; color:#2a0a4a; font-size:10px; font-weight:700; display:flex; align-items:center; justify-content:center; border:2px solid #16304C; margin-left:-7px;">T</span>
+          <span style="width:24px; height:24px; border-radius:50%; background:#ff7a59; color:#5a1e0c; font-size:10px; font-weight:700; display:flex; align-items:center; justify-content:center; border:2px solid #16304C; margin-left:-7px;">N</span>
         </div>
-
-        <div class="palette" id="palette" role="listbox" aria-label="Commands">
-          <div class="palette__list" id="paletteList">
-            {commandItems.map((item) => (
-              <button
-                class="cmd-row"
-                role="option"
-                type="button"
-                data-kind={item.kind}
-                data-value={item.value}
-                data-search={`${item.label} ${item.group}`.toLowerCase()}
-              >
-                <span class="cmd-bar"></span>
-                <span class="cmd-left">
-                  <span class={`cmd-dot${item.kind === 'link' ? ' is-faint' : ''}`}></span>
-                  <span class="cmd-label">{item.label}</span>
-                </span>
-                <span class="cmd-group">{item.group}</span>
-              </button>
-            ))}
-            <div class="palette__empty" id="paletteEmpty" hidden>No matches.</div>
-          </div>
-          <div class="palette__foot"><span>↑↓ navigate</span><span>↵ select</span><span>esc close</span></div>
-        </div>
-      </div>
-    </div>
-
-    <!-- hero -->
-    <div class="hero">
-      <div class="hero__left">
-        <h1 class="hero__title">Helping complex developer tools make a little more sense.</h1>
-        <div class="currently">
-          <div class="currently__rule"></div>
-          <div class="currently__kickers"><span class="lead">Currently</span><span>Observability</span></div>
-          <div class="currently__statement">Building developer tooling at <em>Dynatrace.</em></div>
-        </div>
-      </div>
-
-      <nav class="work-nav" aria-label="Writing and selected work">
-        <span class="work-nav__kicker">Writing</span>
-        <button class="work-link" type="button" data-go="notes" aria-label="Open notes">
-          <span class="work-link__name">Notes</span>
-          {latestNote && <span class="work-link__cap">latest — {latestNote.data.title}</span>}
-        </button>
-
-        <div class="work-nav__sep" role="presentation"></div>
-
-        <span class="work-nav__kicker">Selected work</span>
-        {selectedWork.map((w) => (
-          <a class="work-link" href={w.url} aria-label={w.locked ? `${w.name} (password protected)` : w.name}>
-            <span class="work-link__name">
-              {w.name}
-              {w.locked && (
-                <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" aria-hidden="true"><rect x="5" y="11" width="14" height="9" rx="1.5"></rect><path d="M8 11V7a4 4 0 0 1 8 0v4"></path></svg>
-              )}
-            </span>
-            <span class="work-link__cap">{w.caption}</span>
-          </a>
-        ))}
-      </nav>
-    </div>
-
-    <!-- footer -->
-    <div class="footer">
-      <div class="footer__left">
-        <button class="footer__hint" id="footerHint" type="button">Press <span class="key">⌘</span> <span class="key">K</span> to look around</button>
-        <span class="live">
-          <span class="live__dot"><span class="ring"></span><span class="core"></span></span>
-          <span>Lisbon · <span class="live__clock" id="clock">—:—:—</span> · 38.6892603333238 · last seen at the Gulbenkian</span>
+        <button style="background:var(--accent); color:#102237; border:none; border-radius:6px; padding:7px 14px; font-size:12px; font-weight:500; cursor:pointer;">Share</button>
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="#C2C9D4"><path d="M6 4l14 8-14 8z"></path></svg>
+        <span style="display:flex; align-items:center; gap:4px; color:#C2C9D4;">100%
+          <svg width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="#5A6473" stroke-width="2.4"><path d="M6 9l6 6 6-6"></path></svg>
         </span>
       </div>
-      <div class="footer__links">
-        <button type="button" data-go="notes">Notes</button>
-        <a href={`mailto:${contact.email}`}>Email</a>
-        <a href={contact.bluesky.url} target="_blank" rel="noopener noreferrer">Bluesky</a>
-        <a href={contact.github.url} target="_blank" rel="noopener noreferrer">GitHub</a>
+    </div>
+
+    <!-- left panel -->
+    <div data-no-pan data-panel="left" style="position:absolute; top:46px; left:0; bottom:0; width:240px; background:#16304C; border-right:1px solid #0A1626; z-index:5; display:flex; flex-direction:column; font-size:12px;">
+      <div style="display:flex; gap:14px; padding:11px 14px; border-bottom:1px solid #1C3650;">
+        <span style="color:#fff; border-bottom:2px solid #fff; padding-bottom:8px; margin-bottom:-12px;">Layers</span>
+        <span style="color:#8B94A3;">Assets</span>
+      </div>
+      <div style="padding:10px 12px;">
+        <div style="display:flex; align-items:center; gap:7px; background:#20395A; border-radius:6px; padding:6px 9px; color:#9AA3B0;">
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="10" cy="10" r="6"></circle><path d="M20 20l-5-5"></path></svg>
+          <span>Search layers</span>
+        </div>
+      </div>
+      <div style="flex:1; overflow:auto; padding:2px 6px;">
+        <div style="display:flex; align-items:center; gap:6px; height:28px; padding:0 6px; color:#9AA3B0;">
+          <svg width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M6 9l6 6 6-6"></path></svg>
+          <span style="color:#C2C9D4;"># Page 1</span>
+        </div>
+        <div data-layer="about" style="display:flex; align-items:center; gap:7px; height:28px; padding:0 6px 0 18px; border-radius:4px; cursor:pointer; color:#fff;">
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"><path d="M8 3v18M16 3v18M3 8h18M3 16h18"></path></svg><span>About</span>
+        </div>
+        <div style="display:flex; align-items:center; gap:7px; height:25px; padding:0 6px 0 42px; color:#8B94A3;"><span style="font-weight:700; width:13px; text-align:center;">T</span><span>Nilson Gaspar</span></div>
+        <div style="display:flex; align-items:center; gap:7px; height:25px; padding:0 6px 0 42px; color:#8B94A3;"><span style="font-weight:700; width:13px; text-align:center;">¶</span><span>Bio</span></div>
+        <div style="display:flex; align-items:center; gap:7px; height:25px; padding:0 6px 0 42px; color:#8B94A3;"><span style="font-weight:700; width:13px; text-align:center;">"</span><span>Quote</span></div>
+        <div data-layer="why" style="display:flex; align-items:center; gap:7px; height:28px; padding:0 6px 0 18px; border-radius:4px; cursor:pointer; color:#C2C9D4;">
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"><path d="M8 3v18M16 3v18M3 8h18M3 16h18"></path></svg><span>Why</span>
+        </div>
+        <div data-layer="principles" style="display:flex; align-items:center; gap:7px; height:28px; padding:0 6px 0 18px; border-radius:4px; cursor:pointer; color:#C2C9D4;">
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"><path d="M8 3v18M16 3v18M3 8h18M3 16h18"></path></svg><span>Principles</span>
+        </div>
+        <div data-layer="ia" style="display:flex; align-items:center; gap:7px; height:28px; padding:0 6px 0 18px; border-radius:4px; cursor:pointer; color:#C2C9D4;">
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"><path d="M8 3v18M16 3v18M3 8h18M3 16h18"></path></svg><span>Sitemap</span>
+        </div>
+        <div data-layer="home" style="display:flex; align-items:center; gap:7px; height:28px; padding:0 6px 0 18px; border-radius:4px; cursor:pointer; color:#C2C9D4;">
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"><path d="M8 3v18M16 3v18M3 8h18M3 16h18"></path></svg><span>Homepage</span>
+        </div>
       </div>
     </div>
+
+    <!-- right panel -->
+    <div data-no-pan data-panel="right" style="position:absolute; top:46px; right:0; bottom:0; width:240px; background:#16304C; border-left:1px solid #0A1626; z-index:5; overflow:auto; font-size:11px; color:#8B94A3;">
+      <div style="display:flex; align-items:center; justify-content:space-between; padding:10px 12px; border-bottom:1px solid #1C3650;">
+        <div style="display:flex; gap:3px;">
+          <span class="icon-btn" style="width:24px; height:24px; border-radius:5px; display:flex; align-items:center; justify-content:center;"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#C2C9D4" stroke-width="1.6"><path d="M4 4v16M9 8h11M9 16h7"></path></svg></span>
+          <span class="icon-btn" style="width:24px; height:24px; border-radius:5px; display:flex; align-items:center; justify-content:center;"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#C2C9D4" stroke-width="1.6"><path d="M12 4v16M5 8h14M7 16h10"></path></svg></span>
+          <span class="icon-btn" style="width:24px; height:24px; border-radius:5px; display:flex; align-items:center; justify-content:center;"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#C2C9D4" stroke-width="1.6"><path d="M20 4v16M15 8H4M15 16h-7"></path></svg></span>
+        </div>
+        <div style="display:flex; gap:3px;">
+          <span class="icon-btn" style="width:24px; height:24px; border-radius:5px; display:flex; align-items:center; justify-content:center;"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#C2C9D4" stroke-width="1.6"><path d="M4 4h16M8 9v11M16 9v7"></path></svg></span>
+          <span class="icon-btn" style="width:24px; height:24px; border-radius:5px; display:flex; align-items:center; justify-content:center;"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#C2C9D4" stroke-width="1.6"><path d="M4 12h16M8 5v14M16 5v14"></path></svg></span>
+          <span class="icon-btn" style="width:24px; height:24px; border-radius:5px; display:flex; align-items:center; justify-content:center;"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#C2C9D4" stroke-width="1.6"><path d="M4 20h16M8 4v11M16 4v7"></path></svg></span>
+        </div>
+      </div>
+      <div style="padding:12px;">
+        <div style="color:#E7EAF0; font-weight:500; margin-bottom:9px;">Position</div>
+        <div style="display:flex; gap:8px; margin-bottom:8px;">
+          <div style="flex:1; display:flex; align-items:center; gap:6px; background:#20395A; border-radius:5px; padding:6px 8px;"><span style="color:#525B69;">X</span><span data-field="x" style="color:#E7EAF0;">80</span></div>
+          <div style="flex:1; display:flex; align-items:center; gap:6px; background:#20395A; border-radius:5px; padding:6px 8px;"><span style="color:#525B69;">Y</span><span data-field="y" style="color:#E7EAF0;">70</span></div>
+        </div>
+        <div style="display:flex; gap:8px;">
+          <div style="flex:1; display:flex; align-items:center; gap:6px; background:#20395A; border-radius:5px; padding:6px 8px;"><span style="color:#525B69;">W</span><span data-field="w" style="color:#E7EAF0;">520</span></div>
+          <div style="flex:1; display:flex; align-items:center; gap:6px; background:#20395A; border-radius:5px; padding:6px 8px;"><span style="color:#525B69;">H</span><span data-field="h" style="color:#E7EAF0;">580</span></div>
+        </div>
+      </div>
+      <div style="padding:0 12px 12px; border-bottom:1px solid #1C3650;">
+        <div style="color:#E7EAF0; font-weight:500; margin:6px 0 9px;">Layer</div>
+        <div style="display:flex; gap:8px;">
+          <div style="flex:1; display:flex; align-items:center; gap:6px; background:#20395A; border-radius:5px; padding:6px 8px;"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#525B69" stroke-width="2"><circle cx="12" cy="12" r="9"></circle></svg><span style="color:#E7EAF0;">100</span><span style="color:#525B69; margin-left:auto;">%</span></div>
+          <div style="flex:1; display:flex; align-items:center; gap:6px; background:#20395A; border-radius:5px; padding:6px 8px;"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#525B69" stroke-width="2"><path d="M4 9V5h4M20 9V5h-4M4 15v4h4M20 15v4h-4"></path></svg><span style="color:#E7EAF0;">0</span></div>
+        </div>
+      </div>
+      <div style="padding:12px; border-bottom:1px solid #1C3650;">
+        <div style="display:flex; align-items:center; justify-content:space-between; color:#E7EAF0; font-weight:500; margin-bottom:9px;">Fill <span style="color:#525B69; font-size:14px;">+</span></div>
+        <div style="display:flex; align-items:center; gap:8px; background:#20395A; border-radius:5px; padding:5px 8px;">
+          <span data-field="fillsw" style="width:16px; height:16px; border-radius:3px; background:#182E49; border:1px solid #3F5C82;"></span>
+          <span data-field="fillhex" style="color:#E7EAF0; letter-spacing:.02em;">182E49</span>
+          <span style="color:#525B69; margin-left:auto;">100%</span>
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="#525B69" stroke-width="1.6"><path d="M2 12s4-7 10-7 10 7 10 7-4 7-10 7S2 12 2 12z"></path><circle cx="12" cy="12" r="2.5"></circle></svg>
+        </div>
+      </div>
+      <div style="padding:12px;">
+        <div style="display:flex; align-items:center; justify-content:space-between; color:#E7EAF0; font-weight:500;">Export <span style="color:#525B69; font-size:14px;">+</span></div>
+      </div>
+    </div>
+
+    <!-- bottom toolbar -->
+    <div data-no-pan data-panel="toolbar" style="position:absolute; bottom:18px; left:50%; transform:translateX(-50%); z-index:6; display:flex; align-items:center; gap:2px; background:#16304C; border:1px solid #0A1626; border-radius:13px; padding:6px; box-shadow:0 8px 26px rgba(0,0,0,.45);">
+      <button style="width:36px; height:36px; border:none; background:var(--accent); border-radius:9px; color:#102237; display:flex; align-items:center; justify-content:center; cursor:pointer;"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M5 2l15 8-6.5 1.6L10 21z"></path></svg></button>
+      <button class="icon-btn" style="width:36px; height:36px; border:none; background:transparent; border-radius:9px; color:#C2C9D4; display:flex; align-items:center; justify-content:center; cursor:pointer;"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"><path d="M8 3v18M16 3v18M3 8h18M3 16h18"></path></svg></button>
+      <button class="icon-btn" style="width:36px; height:36px; border:none; background:transparent; border-radius:9px; color:#C2C9D4; display:flex; align-items:center; justify-content:center; cursor:pointer;"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"><rect x="4" y="4" width="16" height="16" rx="2"></rect></svg></button>
+      <button class="icon-btn" style="width:36px; height:36px; border:none; background:transparent; border-radius:9px; color:#C2C9D4; display:flex; align-items:center; justify-content:center; cursor:pointer;"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"><path d="M12 19l7-7-3.5-3.5L8 16l-2 5z"></path><path d="M14 7l3 3"></path></svg></button>
+      <button class="icon-btn" style="width:36px; height:36px; border:none; background:transparent; border-radius:9px; color:#C2C9D4; display:flex; align-items:center; justify-content:center; cursor:pointer; font-weight:700; font-size:16px;">T</button>
+      <div style="width:1px; height:22px; background:#2C476A; margin:0 4px;"></div>
+      <button class="icon-btn" style="width:36px; height:36px; border:none; background:transparent; border-radius:9px; color:#C2C9D4; display:flex; align-items:center; justify-content:center; cursor:pointer;"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"><path d="M4 5h16v11H10l-4 4z"></path></svg></button>
+    </div>
+
   </div>
 
-  <!-- palette outside-click catcher -->
-  <div class="catcher" id="catcher"></div>
+  <!-- ===================================================== -->
+  <!-- ===== Cover: the composed homepage (on top) ========= -->
+  <!-- ===================================================== -->
+  <div data-sheet style="position:absolute; inset:0; z-index:3; background:#102237; color:#E7EAF0; will-change:clip-path;">
+    <div style="position:absolute; inset:0; display:flex; flex-direction:column; padding:clamp(40px,5vw,64px);">
 
-  <!-- slide-over -->
-  <div class="scrim" id="scrim"></div>
-  <div class="drawer" id="drawer" role="dialog" aria-modal="true" aria-label="Section panel">
-    <div class="sheet">
-      <div class="sheet__chrome">
-        <span class="sheet__kicker"><span class="lead">Nilson Gaspar</span><span>/ <span id="sheetTitle"></span></span></span>
-        <button class="sheet__close" id="sheetClose" type="button">Close <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 6l12 12M18 6L6 18"></path></svg></button>
-      </div>
-
-      <!-- About -->
-      <section class="sheet-view" data-view="about">
-        <h2 class="about__standfirst">I design developer tools that feel surprisingly human.</h2>
-        <div class="about__cols">
-          <aside class="about__meta">
-            <div class="meta-row"><span class="meta-row__label">Focus</span><span class="meta-row__value">Developer tools · observability</span></div>
-            <div class="meta-row"><span class="meta-row__label">Now</span><span class="meta-row__value">Dynatrace</span></div>
-            <div class="meta-row"><span class="meta-row__label">Before</span><span class="meta-row__value">Grafana Labs</span></div>
-            <div class="meta-row"><span class="meta-row__label">Based</span><span class="meta-row__value">Lisbon, Portugal</span></div>
-          </aside>
-          <div class="about__body">
-            <p class="about__lead">I'm a product designer working in developer tools and observability — at Dynatrace now, Grafana Labs before that. My background runs across visual design, frontend, and the messy technical middle, which helps me shape genuinely complex products that still feel human to use.</p>
-            <p class="about__lead">Dense, high-stakes problems are the ones I like most. Turning observability data into something a developer can actually act on taught me that the harder the technical challenge, the more good design is worth.</p>
-
-            <div class="pull">
-              <div class="pull__kicker">On the work</div>
-              <blockquote class="pull__quote">"There's nothing quite like making a developer say <em>finally, this makes sense.</em>"</blockquote>
-            </div>
-
-            <div class="principles">
-              <div class="principle">
-                <span class="principle__num">01</span>
-                <div><div class="principle__title">Real-time impact at scale</div><div class="principle__desc">When the work ships it isn't a mock — it's thousands of engineers moving a little faster every day.</div></div>
-              </div>
-              <div class="principle">
-                <span class="principle__num">02</span>
-                <div><div class="principle__title">Collaboration over isolation</div><div class="principle__desc">Working shoulder to shoulder with engineers sharpened how I think. I ask "what's technically possible?" before "what's ideal?"</div></div>
-              </div>
-              <div class="principle">
-                <span class="principle__num">03</span>
-                <div><div class="principle__title">Art &amp; science</div><div class="principle__desc">Visualizing dense data takes aesthetic judgment and a real grasp of how developers actually work.</div></div>
-              </div>
-            </div>
-          </div>
+      <div style="flex:1; display:flex; align-items:center;">
+       <div data-cover-row style="width:100%; display:flex; align-items:flex-start; justify-content:space-between; gap:clamp(36px,5vw,72px); flex-wrap:wrap;">
+        <div style="flex:1 1 360px; max-width:660px;">
+          <h1 style="margin:0; font-weight:500; font-size:clamp(2.3rem,5vw,4.8rem); line-height:1.0; letter-spacing:-.028em;">I make complex developer tools feel a little more <span style="text-decoration:underline; text-decoration-color:#54E0A6; text-underline-offset:.1em; text-decoration-thickness:.05em;">human</span>.</h1>
+          <p style="margin:clamp(22px,2.6vw,32px) 0 0; font-size:clamp(15px,1.4vw,17px); line-height:1.5; color:#AEB4BE; max-width:32ch;">Most recently, I was designing developer tools at <a class="dyn-link" href={DYNATRACE_URL} target="_blank" rel="noopener noreferrer" style="color:#E7EAF0; text-decoration:underline; text-decoration-color:#54E0A6; text-underline-offset:.15em; text-decoration-thickness:.05em;">Dynatrace</a>.</p>
         </div>
-      </section>
 
-      <!-- Work -->
-      <section class="sheet-view" data-view="work">
-        <div class="rows">
-          {selectedWork.map((w) => (
-            <a class="row" href={w.url}>
-              <div><div class="row__title">{w.name}</div><div class="row__desc">{w.blurb}</div></div>
-              <span class={`row__tag${w.tenure === 'now' ? ' is-now' : ''}`}>{w.tenure}</span>
+        <nav data-cover-nav style="display:flex; flex-direction:column; align-items:flex-end; gap:clamp(18px,2.2vw,26px); flex:none; margin-left:auto; text-align:right; max-width:46vw;">
+
+          <div style="display:flex; flex-direction:column; align-items:flex-end; gap:clamp(11px,1.4vw,15px);">
+            <span style="font-family:var(--mono); font-size:12px; letter-spacing:.22em; text-transform:uppercase; color:#8B94A3;">Writing</span>
+            <a href="/notes" style="display:flex; flex-direction:column; align-items:flex-end; gap:5px;">
+              <span style="font-size:clamp(1.4rem,2.1vw,1.8rem); font-weight:500; letter-spacing:-.018em; line-height:1; color:#E7EAF0;">Notes</span>
+              {latestNote && <span style="font-family:var(--mono); font-size:12px; letter-spacing:.02em; color:#8B94A3;">latest — {latestNote.data.title}</span>}
             </a>
-          ))}
-        </div>
-      </section>
+          </div>
 
-      <!-- Notes -->
-      <section class="sheet-view" data-view="notes">
-        <p class="sheet__lead">Occasional writing on design, developer experience, and making dense data legible.</p>
-        {recentNotes.length > 0 ? (
-          <div class="rows">
-            {recentNotes.map((note) => (
-              <a class="row note-row" href={`/notes/${note.slug}`}>
-                <span class="row__title">{note.data.title}</span>
-                <span class="row__year">{note.data.publishDate.getFullYear()}</span>
+          <div data-cover-divider style="width:min(300px,42vw); height:1px; background:#2C476A;"></div>
+
+          <div style="display:flex; flex-direction:column; align-items:flex-end; gap:clamp(11px,1.4vw,15px);">
+            <span style="font-family:var(--mono); font-size:12px; letter-spacing:.22em; text-transform:uppercase; color:#8B94A3;">Selected work</span>
+            {selectedWork.map((w) => (
+              <a href={w.url} aria-label={w.locked ? `${w.name} (password protected)` : w.name} style="display:flex; flex-direction:column; align-items:flex-end; gap:5px;">
+                <span style="display:inline-flex; align-items:center; gap:9px; font-size:clamp(1.4rem,2.1vw,1.8rem); font-weight:500; letter-spacing:-.018em; line-height:1; color:#E7EAF0;">
+                  {w.name}
+                  {w.locked && (
+                    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><rect x="5" y="11" width="14" height="9" rx="1.5"></rect><path d="M8 11V7a4 4 0 0 1 8 0v4"></path></svg>
+                  )}
+                </span>
+                <span style="font-family:var(--mono); font-size:12px; letter-spacing:.02em; color:#8B94A3;">{w.caption}</span>
               </a>
             ))}
           </div>
-        ) : (
-          <p class="sheet__lead">No notes published yet.</p>
-        )}
-        <a class="notes-more" href="/notes">View all notes →</a>
-      </section>
+        </nav>
+       </div>
+      </div>
 
-      <!-- Contact -->
-      <section class="sheet-view" data-view="contact">
-        <p class="sheet__lead">Building something where design is the hard part? Let's talk.</p>
-        <div class="rows">
-          <a class="row contact-row" href={`mailto:${contact.email}`}><span class="contact-row__label">Email</span><span class="contact-row__value">{contact.email}</span></a>
-          <a class="row contact-row" href={contact.bluesky.url} target="_blank" rel="noopener noreferrer"><span class="contact-row__label">Bluesky</span><span class="contact-row__value">{contact.bluesky.handle}</span></a>
-          <a class="row contact-row" href={contact.github.url} target="_blank" rel="noopener noreferrer"><span class="contact-row__label">GitHub</span><span class="contact-row__value">{contact.github.handle}</span></a>
-          <div class="row contact-row"><span class="contact-row__label">Based in</span><span class="contact-row__value">{contact.based}</span></div>
+      <div class="cover-footer" style="display:flex; align-items:flex-end; justify-content:space-between; gap:2rem; flex-wrap:wrap;">
+        <div style="display:flex; flex-direction:column; gap:.7rem;">
+          <span style="font-family:var(--mono); font-size:.78rem; color:#8B94A3;">38.6892603333238</span>
+          <span style="font-size:.74rem; letter-spacing:.07em; text-transform:uppercase; color:#8B94A3;">Last seen 2 days ago, at Gulbenkian Art Gallery in Lisbon.</span>
         </div>
-      </section>
+        <div style="display:flex; gap:1.2rem; font-size:.76rem; letter-spacing:.09em; text-transform:uppercase; color:#8B94A3;">
+          <a href={`mailto:${contact.email}`}>Email</a>
+          <a href={contact.bluesky.url} target="_blank" rel="noopener noreferrer">Bluesky</a>
+          <a href={contact.github.url} target="_blank" rel="noopener noreferrer">Github</a>
+        </div>
+      </div>
+
     </div>
   </div>
 
-  <div class="toast" id="toast" role="status" aria-live="polite"></div>
+  <!-- curl / flap -->
+  <div data-flap style="position:absolute; inset:0; z-index:4; pointer-events:none; background:linear-gradient(225deg,#325081 0%,#21406A 42%,#122441 100%); filter:drop-shadow(-3px 4px 12px rgba(0,0,0,.5));"></div>
 
-  <script>
-    const EMAIL = 'hello@nilsongaspar.com';
-    const SHEET_TITLES: Record<string, string> = { about: 'About', work: 'Work', notes: 'Notes', contact: 'Contact' };
+  <!-- corner hint -->
+  <div data-hint style="position:absolute; top:26px; right:54px; z-index:3; pointer-events:none; display:flex; align-items:center; gap:8px; font-family:var(--mono); font-size:11px; letter-spacing:.14em; text-transform:uppercase; color:var(--accent); animation:hintPulse 2.6s ease-in-out infinite;">
+    <span>About me</span>
+    <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M7 17L17 7"></path><path d="M9 7h8v8"></path></svg>
+  </div>
 
-    const field = document.getElementById('searchField')!;
-    const input = document.getElementById('searchInput') as HTMLInputElement;
-    const palette = document.getElementById('palette')!;
-    const paletteEmpty = document.getElementById('paletteEmpty')!;
-    const catcher = document.getElementById('catcher')!;
-    const scrim = document.getElementById('scrim')!;
-    const drawer = document.getElementById('drawer')!;
-    const sheetTitle = document.getElementById('sheetTitle')!;
-    const toast = document.getElementById('toast')!;
-    const rows = Array.from(document.querySelectorAll<HTMLElement>('.cmd-row'));
-    const sheetViews = Array.from(document.querySelectorAll<HTMLElement>('.sheet-view'));
+  <!-- back to cover -->
+  <button data-back class="back-btn" style="position:absolute; top:9px; left:12px; z-index:8; background:transparent; border:none; cursor:pointer; color:#C2C9D4; font-family:var(--mono); font-size:11px; letter-spacing:.1em; text-transform:uppercase; padding:6px 9px; border-radius:6px; display:flex; align-items:center; gap:6px; opacity:0; pointer-events:none; transition:opacity .25s ease;">↖ Cover</button>
 
-    let open = false;
-    let sheet: string | null = null;
-    let activeIndex = 0;
-    let toastTimer: number | undefined;
+</div>
 
-    const visibleRows = () => rows.filter((r) => !r.hidden);
+<script>
+  // Peel + workspace controller. Ported from the design prototype's class to a
+  // plain closure — the only real state is `peeled`; everything else is per-frame
+  // imperative geometry driven by a rAF loop (the fold needs live clip-path math).
+  // ponytail: one file, no component/hook wrapper — matches the rest of the site.
+  type Pt = [number, number];
+  type Frame = { name: string; x: number; y: number; w: number; h: number; fill: string };
 
-    function paintActive() {
-      const vis = visibleRows();
-      rows.forEach((r) => r.classList.remove('is-active'));
-      const el = vis[activeIndex];
-      if (el) {
-        el.classList.add('is-active');
-        el.scrollIntoView({ block: 'nearest' });
-      }
+  const $ = <T extends Element = HTMLElement>(sel: string) => document.querySelector(sel) as T;
+
+  const stage = $('[data-stage]');
+  const sheet = $('[data-sheet]');
+  const flap = $('[data-flap]');
+  const about = $('[data-about]');
+  const back = $('[data-back]');
+  const hint = $('[data-hint]');
+  const canvasBg = $('[data-canvasbg]');
+  const group = $('[data-group]');
+
+  const T0 = 66, HOVER_T = 172, CURL_D = 175;
+  const frames: Record<string, Frame> = {
+    about:      { name: 'About',      x: 80,  y: 70,  w: 520, h: 580, fill: '#182E49' },
+    why:        { name: 'Why',        x: 680, y: 70,  w: 480, h: 420, fill: '#182E49' },
+    principles: { name: 'Principles', x: 680, y: 540, w: 620, h: 280, fill: '#182E49' },
+    ia:         { name: 'Sitemap',    x: 700, y: 880, w: 720, h: 580, fill: '#182E49' },
+    home:       { name: 'Homepage',   x: 80,  y: 700, w: 380, h: 230, fill: '#102237' },
+  };
+  const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+  let peeled = false;
+  let W = 0, H = 0, rectLeft = 0, rectTop = 0;
+  let t = T0, target = T0;
+  let dragging = false, opening = false, hovering = false, userActed = false;
+  let downX = 0, downY = 0, moved = false, breathT = 0;
+  let panX = 0, panY = 0, ptx = 0, pty = 0;
+  let panning = false, psx = 0, psy = 0, bx = 0, by = 0;
+
+  // ---------- geometry ----------
+  const measure = () => {
+    const r = stage.getBoundingClientRect();
+    W = r.width; H = r.height; rectLeft = r.left; rectTop = r.top;
+  };
+  const rect4 = (): Pt[] => [[0, 0], [W, 0], [W, H], [0, H]];
+
+  function clipHalf(poly: Pt[], thr: number, keepGE: boolean): Pt[] {
+    if (!poly.length) return poly;
+    const g = (p: Pt) => (W - p[0]) + p[1];
+    const inside = (p: Pt) => (keepGE ? g(p) >= thr : g(p) <= thr);
+    const inter = (a: Pt, b: Pt): Pt => {
+      const ga = g(a) - thr, gb = g(b) - thr, u = ga / (ga - gb);
+      return [a[0] + u * (b[0] - a[0]), a[1] + u * (b[1] - a[1])];
+    };
+    const out: Pt[] = [];
+    for (let i = 0; i < poly.length; i++) {
+      const cur = poly[i], prev = poly[(i + poly.length - 1) % poly.length];
+      const ci = inside(cur), pi = inside(prev);
+      if (ci) { if (!pi) out.push(inter(prev, cur)); out.push(cur); }
+      else if (pi) { out.push(inter(prev, cur)); }
     }
+    return out;
+  }
+  const reflectPt = (p: Pt, thr: number): Pt => {
+    const signed = (-p[0] + p[1] + W - thr) / 2;
+    return [p[0] + 2 * signed, p[1] - 2 * signed];
+  };
+  const toClip = (poly: Pt[]) =>
+    poly.length < 3 ? 'polygon(0 0, 0 0, 0 0)'
+      : 'polygon(' + poly.map((p) => p[0].toFixed(1) + 'px ' + p[1].toFixed(1) + 'px').join(', ') + ')';
 
-    function filter(q: string) {
-      const term = q.trim().toLowerCase();
-      let shown = 0;
-      rows.forEach((r) => {
-        const match = !term || (r.dataset.search || '').includes(term);
-        r.hidden = !match;
-        if (match) shown++;
-      });
-      (paletteEmpty as HTMLElement).hidden = shown > 0;
-      activeIndex = 0;
-      paintActive();
-    }
+  function apply(val: number) {
+    sheet.style.clipPath = toClip(clipHalf(rect4(), val, true));
+    let band = clipHalf(rect4(), val, false);
+    band = clipHalf(band, val - CURL_D, true);
+    flap.style.clipPath = toClip(band.map((p) => reflectPt(p, val)));
+  }
+  const inCorner = (x: number, y: number) => x > W - 210 && y < 210;
 
-    function openPalette() {
-      open = true;
-      palette.classList.add('is-open');
-      catcher.classList.add('is-open');
-      input.value = '';
-      filter('');
-      setTimeout(() => input.focus(), 30);
-    }
-    function closePalette() {
-      open = false;
-      palette.classList.remove('is-open');
-      catcher.classList.remove('is-open');
-      input.blur();
-    }
-
-    function openSheet(view: string) {
-      sheet = view;
-      sheetTitle.textContent = SHEET_TITLES[view] || '';
-      sheetViews.forEach((v) => v.classList.toggle('is-active', v.dataset.view === view));
-      drawer.classList.add('is-open');
-      scrim.classList.add('is-open');
-      closePalette();
-    }
-    function closeSheet() {
-      sheet = null;
-      drawer.classList.remove('is-open');
-      scrim.classList.remove('is-open');
-    }
-
-    function showToast(msg: string) {
-      toast.textContent = msg;
-      toast.classList.add('is-visible');
-      clearTimeout(toastTimer);
-      toastTimer = window.setTimeout(() => toast.classList.remove('is-visible'), 1900);
-    }
-
-    function runRow(row: HTMLElement) {
-      const kind = row.dataset.kind;
-      const value = row.dataset.value || '';
-      if (kind === 'nav') {
-        openSheet(value);
-      } else if (kind === 'copy') {
-        navigator.clipboard?.writeText(value).catch(() => {});
-        closePalette();
-        showToast('Copied ' + value);
-      } else if (value.startsWith('http')) {
-        window.open(value, '_blank', 'noopener');
-        closePalette();
-      } else {
-        window.location.href = value;
-      }
-    }
-
-    // palette interactions
-    input.addEventListener('input', () => filter(input.value));
-    input.addEventListener('focus', openPalette);
-    input.addEventListener('keydown', (e) => {
-      const vis = visibleRows();
-      if (e.key === 'ArrowDown') { e.preventDefault(); if (vis.length) { activeIndex = (activeIndex + 1) % vis.length; paintActive(); } }
-      else if (e.key === 'ArrowUp') { e.preventDefault(); if (vis.length) { activeIndex = (activeIndex - 1 + vis.length) % vis.length; paintActive(); } }
-      else if (e.key === 'Enter') { e.preventDefault(); if (vis[activeIndex]) runRow(vis[activeIndex]); }
-      else if (e.key === 'Escape') { e.preventDefault(); closePalette(); }
+  // ---------- workspace ----------
+  const applyPan = () => { group.style.transform = `translate(${panX}px,${panY}px)`; };
+  function centerTargets(f: Frame) {
+    ptx = W / 2 - (f.x + f.w / 2);
+    pty = (46 + H) / 2 - (f.y + f.h / 2);
+  }
+  function select(key: string) {
+    const f = frames[key]; if (!f) return;
+    const selBox = $('[data-sel]');
+    if (selBox) { selBox.style.left = f.x + 'px'; selBox.style.top = f.y + 'px'; selBox.style.width = f.w + 'px'; selBox.style.height = f.h + 'px'; }
+    const dim = $('[data-seldim]'); if (dim) dim.textContent = `${f.w} × ${f.h}`;
+    const set = (k: string, v: string) => { const el = $(`[data-field="${k}"]`); if (el) el.textContent = v; };
+    set('x', String(f.x)); set('y', String(f.y)); set('w', String(f.w)); set('h', String(f.h));
+    set('fillhex', f.fill.replace('#', '').toUpperCase());
+    const sw = $('[data-field="fillsw"]'); if (sw) sw.style.background = f.fill;
+    if (peeled) centerTargets(f);
+    document.querySelectorAll<HTMLElement>('[data-layer]').forEach((el) => {
+      const on = el.dataset.layer === key;
+      el.style.background = on ? 'rgba(84,224,166,.20)' : 'transparent';
+      el.style.color = on ? '#fff' : '#C2C9D4';
     });
-    rows.forEach((row) => {
-      row.addEventListener('click', () => runRow(row));
-      row.addEventListener('mousemove', () => {
-        const vis = visibleRows();
-        const i = vis.indexOf(row);
-        if (i >= 0 && i !== activeIndex) { activeIndex = i; paintActive(); }
-      });
+    document.querySelectorAll<HTMLElement>('[data-framelabel]').forEach((el) => {
+      el.style.color = el.dataset.framelabel === key ? 'var(--accent)' : '#8B94A3';
     });
-    catcher.addEventListener('click', closePalette);
-    field.addEventListener('click', () => { if (!open) openPalette(); });
-    document.getElementById('footerHint')!.addEventListener('click', openPalette);
+  }
 
-    // slide-over triggers
-    scrim.addEventListener('click', closeSheet);
-    document.getElementById('sheetClose')!.addEventListener('click', closeSheet);
-    document.querySelectorAll<HTMLElement>('[data-go]').forEach((el) =>
-      el.addEventListener('click', () => openSheet(el.dataset.go!)),
-    );
+  // ---------- peel / pan state ----------
+  function applyPeelState() {
+    sheet.style.pointerEvents = peeled ? 'none' : 'auto';
+    about.style.pointerEvents = peeled ? 'auto' : 'none';
+    back.style.opacity = peeled ? '1' : '0';
+    back.style.pointerEvents = peeled ? 'auto' : 'none';
+  }
+  function updateHint() {
+    const show = !userActed && !peeled && !hovering;
+    hint.style.opacity = show ? '' : '0';
+    hint.style.animation = show ? '' : 'none';
+  }
 
-    // global keys
-    window.addEventListener('keydown', (e) => {
-      const k = e.key.toLowerCase();
-      if (k === 'k' && (e.metaKey || e.ctrlKey)) { e.preventDefault(); open ? closePalette() : openPalette(); return; }
-      if (e.key === 'Escape') { if (sheet) closeSheet(); else if (open) closePalette(); return; }
-      if (e.key === '/' && !open && !sheet) {
-        const tag = (e.target as HTMLElement).tagName;
-        if (tag === 'INPUT' || tag === 'TEXTAREA') return;
-        e.preventDefault();
-        openPalette();
-      }
-    });
-
-    // live clock — Europe/Lisbon
-    const clock = document.getElementById('clock')!;
-    function tick() {
-      try {
-        clock.textContent = new Date().toLocaleTimeString('en-GB', { timeZone: 'Europe/Lisbon', hour: '2-digit', minute: '2-digit', second: '2-digit' });
-      } catch {
-        clock.textContent = new Date().toLocaleTimeString();
-      }
+  // ---------- pointer: peel ----------
+  stage.addEventListener('pointerdown', (e) => {
+    if (peeled) return;
+    const x = e.clientX - rectLeft, y = e.clientY - rectTop;
+    if (!inCorner(x, y)) return;
+    userActed = true; updateHint();
+    dragging = true; opening = false;
+    downX = x; downY = y; moved = false;
+    e.preventDefault();
+  });
+  window.addEventListener('pointermove', (e) => {
+    const x = e.clientX - rectLeft, y = e.clientY - rectTop;
+    if (dragging) {
+      target = Math.max(T0, Math.min(W + H, (W - x) + y));
+      if (Math.abs(x - downX) + Math.abs(y - downY) > 7) moved = true;
+      return;
     }
-    tick();
-    setInterval(tick, 1000);
-  </script>
+    if (peeled || opening) return;
+    const was = hovering;
+    hovering = inCorner(x, y);
+    if (hovering !== was) updateHint();
+    if (hovering) target = HOVER_T;
+  });
+  window.addEventListener('pointerup', () => {
+    if (!dragging) return;
+    dragging = false;
+    const threshold = (W + H) * 0.42;
+    if (!moved || target > threshold) { userActed = true; opening = true; target = W + H + 60; }
+    else target = T0;
+  });
+
+  // ---------- pointer: canvas pan ----------
+  canvasBg.addEventListener('pointerdown', (e) => {
+    if (!peeled) return;
+    const tEl = e.target as HTMLElement;
+    if (tEl.closest('[data-frame]') || tEl.closest('[data-no-pan]')) return;
+    panning = true; psx = e.clientX; psy = e.clientY; bx = panX; by = panY;
+    canvasBg.style.cursor = 'grabbing';
+  });
+  window.addEventListener('pointermove', (e) => {
+    if (!panning) return;
+    panX = bx + (e.clientX - psx); panY = by + (e.clientY - psy);
+    ptx = panX; pty = panY; applyPan();
+  });
+  window.addEventListener('pointerup', () => {
+    if (!panning) return;
+    panning = false; canvasBg.style.cursor = 'grab';
+  });
+
+  // ---------- select via frame / layer click ----------
+  document.querySelectorAll<HTMLElement>('[data-frame]').forEach((el) =>
+    el.addEventListener('click', () => select(el.dataset.frame!)));
+  document.querySelectorAll<HTMLElement>('[data-layer]').forEach((el) =>
+    el.addEventListener('click', () => select(el.dataset.layer!)));
+
+  back.addEventListener('click', () => { opening = false; target = T0; peeled = false; applyPeelState(); updateHint(); });
+  window.addEventListener('resize', () => { measure(); apply(t); });
+
+  // ---------- rAF loop ----------
+  function loop() {
+    const idle = !reduceMotion && !userActed && !peeled && !dragging && !hovering && !opening;
+    if (idle) {
+      breathT += 0.018;
+      target = T0 + 14 * (0.5 - 0.5 * Math.cos(breathT));
+    }
+    const k = dragging ? 0.45 : 0.2;
+    t += (target - t) * k;
+    if (Math.abs(target - t) < 0.4) t = target;
+    apply(t);
+    if (opening && t > W + H - 2) { opening = false; peeled = true; applyPeelState(); updateHint(); }
+    if (!panning) {
+      panX += (ptx - panX) * 0.16;
+      panY += (pty - panY) * 0.16;
+      applyPan();
+    }
+    requestAnimationFrame(loop);
+  }
+
+  // ---------- init ----------
+  measure();
+  apply(t);
+  applyPeelState();
+  updateHint();
+  centerTargets(frames.about);
+  panX = ptx; panY = pty; applyPan();
+  select('about');
+  requestAnimationFrame(loop);
+</script>
 </body>
 </html>

--- a/src/pages/notes/[...slug].astro
+++ b/src/pages/notes/[...slug].astro
@@ -58,7 +58,7 @@ const formattedUpdated = updatedDate?.toLocaleDateString('en-US', {
   * { margin: 0; padding: 0; box-sizing: border-box; }
 
   :root {
-    --bg: #161513;
+    --bg: #102237;
     --text: #ffffff;
     --muted: #aaa;
     --dim: #888;
@@ -275,7 +275,7 @@ const formattedUpdated = updatedDate?.toLocaleDateString('en-US', {
   }
 
   .prose pre {
-    background: #1d1b16;
+    background: #16304C;
     border: 1px solid var(--rule);
     padding: 24px;
     border-radius: 6px;

--- a/src/pages/notes/index.astro
+++ b/src/pages/notes/index.astro
@@ -42,7 +42,7 @@ const noteStats = new Map(
   * { margin: 0; padding: 0; box-sizing: border-box; }
 
   :root {
-    --bg: #161513;
+    --bg: #102237;
     --text: #ffffff;
     --muted: #aaa;
     --dim: #888;

--- a/src/pages/notes/tag/[tag].astro
+++ b/src/pages/notes/tag/[tag].astro
@@ -51,7 +51,7 @@ const noteStats = new Map(
   * { margin: 0; padding: 0; box-sizing: border-box; }
 
   :root {
-    --bg: #161513;
+    --bg: #102237;
     --text: #ffffff;
     --muted: #aaa;
     --dim: #888;

--- a/src/pages/projects/dynatrace/index.astro
+++ b/src/pages/projects/dynatrace/index.astro
@@ -34,7 +34,7 @@
 }
 
 body {
-  background: #2a2720;
+  background: #16304C;
   color: #ffffff;
   font-family: -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", sans-serif;
   line-height: 1.6;
@@ -48,7 +48,7 @@ body {
   left: 0;
   right: 0;
   padding: 24px 48px;
-  background: linear-gradient(to bottom, #2a2720 0%, transparent 100%);
+  background: linear-gradient(to bottom, #16304C 0%, transparent 100%);
   z-index: 100;
   backdrop-filter: blur(10px);
   display: flex;
@@ -163,7 +163,7 @@ body {
   display: block;
   text-decoration: none;
   color: inherit;
-  background: linear-gradient(135deg, #211f19 0%, #161513 100%);
+  background: linear-gradient(135deg, #182E49 0%, #102237 100%);
   border: 1px solid rgba(255, 255, 255, 0.05);
   border-radius: 8px;
   overflow: hidden;
@@ -180,7 +180,7 @@ body {
 .project-image {
   width: 100%;
   height: 300px;
-  background: #161513;
+  background: #102237;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/pages/projects/dynatrace/settings-platform.astro
+++ b/src/pages/projects/dynatrace/settings-platform.astro
@@ -23,7 +23,7 @@
 * { margin: 0; padding: 0; box-sizing: border-box; }
 
 body {
-  background: #2a2720;
+  background: #16304C;
   color: #ffffff;
   font-family: -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", sans-serif;
   line-height: 1.6;
@@ -33,7 +33,7 @@ body {
 .nav {
   position: fixed; top: 0; left: 0; right: 0;
   padding: 24px 48px;
-  background: linear-gradient(to bottom, #2a2720 0%, transparent 100%);
+  background: linear-gradient(to bottom, #16304C 0%, transparent 100%);
   z-index: 100; backdrop-filter: blur(10px);
   display: flex; justify-content: space-between; align-items: center;
 }
@@ -106,7 +106,7 @@ body {
 }
 
 .pain-card {
-  padding: 40px; background: #211f19;
+  padding: 40px; background: #182E49;
   border-top: 3px solid #ff6b6b; transition: transform 0.3s;
 }
 
@@ -117,7 +117,7 @@ body {
 
 /* Research Image */
 .research-image {
-  margin: 80px 0; background: #161513; padding: 32px;
+  margin: 80px 0; background: #102237; padding: 32px;
   border-radius: 8px;
 }
 
@@ -139,7 +139,7 @@ body {
 
 /* Insight Card */
 .insight-card {
-  background: #211f19; padding: 48px;
+  background: #182E49; padding: 48px;
   border-left: 4px solid #6c5ce7; border-radius: 4px;
 }
 
@@ -152,7 +152,7 @@ body {
 }
 
 .gallery-item {
-  background: #161513; border-radius: 8px; overflow: hidden;
+  background: #102237; border-radius: 8px; overflow: hidden;
   transition: transform 0.3s;
 }
 
@@ -160,7 +160,7 @@ body {
 .gallery-item img { width: 100%; height: auto; display: block; }
 
 .gallery-caption {
-  padding: 32px 48px; background: #211f19;
+  padding: 32px 48px; background: #182E49;
 }
 
 .gallery-caption h4 { font-size: 20px; color: #fff; margin-bottom: 8px; font-weight: 400; }
@@ -174,7 +174,7 @@ body {
 /* Quote */
 .quote-section {
   padding: 100px 80px; text-align: center;
-  background: linear-gradient(135deg, #211f19 0%, #161513 100%);
+  background: linear-gradient(135deg, #182E49 0%, #102237 100%);
   border-radius: 8px; margin: 120px 0;
 }
 
@@ -193,7 +193,7 @@ body {
 }
 
 .comparison-table th {
-  text-align: left; padding: 16px 24px; background: #211f19;
+  text-align: left; padding: 16px 24px; background: #182E49;
   color: #fff; font-weight: 500; border-bottom: 2px solid rgba(255,255,255,0.1);
 }
 
@@ -207,7 +207,7 @@ body {
 
 /* Impact Section */
 .impact-section {
-  background: #211f19; padding: 80px; border-radius: 8px; margin: 120px 0;
+  background: #182E49; padding: 80px; border-radius: 8px; margin: 120px 0;
 }
 
 .impact-header { text-align: center; margin-bottom: 60px; }

--- a/src/pages/projects/dynatrace/spaces.astro
+++ b/src/pages/projects/dynatrace/spaces.astro
@@ -34,7 +34,7 @@
 }
 
 body {
-  background: #2a2720;
+  background: #16304C;
   color: #ffffff;
   font-family: -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", sans-serif;
   line-height: 1.6;
@@ -48,7 +48,7 @@ body {
   left: 0;
   right: 0;
   padding: 24px 48px;
-  background: linear-gradient(to bottom, #2a2720 0%, transparent 100%);
+  background: linear-gradient(to bottom, #16304C 0%, transparent 100%);
   z-index: 100;
   backdrop-filter: blur(10px);
   display: flex;
@@ -175,7 +175,7 @@ body {
   justify-content: center;
   gap: 24px;
   padding: 48px;
-  background: #211f19;
+  background: #182E49;
   border-radius: 8px;
   margin: 60px 0;
   flex-wrap: wrap;
@@ -255,7 +255,7 @@ body {
 }
 
 .problem-sidebar {
-  background: #211f19;
+  background: #182E49;
   padding: 48px;
   border-radius: 4px;
 }
@@ -282,7 +282,7 @@ body {
 /* Research Image */
 .research-image-container {
   margin: 80px 0;
-  background: #161513;
+  background: #102237;
   padding: 32px;
   border-radius: 8px;
   position: relative;
@@ -312,7 +312,7 @@ body {
 
 .pain-point {
   padding: 40px;
-  background: #211f19;
+  background: #182E49;
   border-top: 3px solid #ff6b6b;
   transition: transform 0.3s;
 }
@@ -345,7 +345,7 @@ body {
 .competitor-table th {
   text-align: left;
   padding: 16px 24px;
-  background: #211f19;
+  background: #182E49;
   color: #fff;
   font-weight: 500;
   border-bottom: 2px solid rgba(255, 255, 255, 0.1);
@@ -395,7 +395,7 @@ body {
 }
 
 .metaphor-card {
-  background: #211f19;
+  background: #182E49;
   padding: 48px;
   border-radius: 8px;
   border-left: 4px solid #1496ff;
@@ -442,7 +442,7 @@ body {
 }
 
 .paradigm-card {
-  background: #2a2720;
+  background: #16304C;
   padding: 48px;
 }
 
@@ -482,7 +482,7 @@ body {
 .quote-section {
   padding: 100px 80px;
   text-align: center;
-  background: linear-gradient(135deg, #211f19 0%, #161513 100%);
+  background: linear-gradient(135deg, #182E49 0%, #102237 100%);
   border-radius: 8px;
   margin: 120px 0;
 }
@@ -513,7 +513,7 @@ body {
 }
 
 .gallery-item {
-  background: #161513;
+  background: #102237;
   border-radius: 8px;
   overflow: hidden;
   transition: transform 0.3s;
@@ -531,7 +531,7 @@ body {
 
 .gallery-caption {
   padding: 32px 48px;
-  background: #211f19;
+  background: #182E49;
 }
 
 .gallery-caption h4 {
@@ -565,7 +565,7 @@ body {
 
 .process-card {
   padding: 40px;
-  background: #211f19;
+  background: #182E49;
   border-radius: 4px;
   border-top: 3px solid #1496ff;
   transition: transform 0.3s;
@@ -597,7 +597,7 @@ body {
 
 /* Impact Section */
 .impact-section {
-  background: #211f19;
+  background: #182E49;
   padding: 80px;
   border-radius: 8px;
   margin: 120px 0;
@@ -656,7 +656,7 @@ body {
 }
 
 .reflection-sidebar {
-  background: #211f19;
+  background: #182E49;
   padding: 48px;
   border-radius: 4px;
   position: sticky;
@@ -686,7 +686,7 @@ body {
   width: 100vw;
   margin-left: calc(-50vw + 50%);
   padding: 80px 48px;
-  background: #161513;
+  background: #102237;
   margin-top: 120px;
   margin-bottom: 120px;
   text-align: center;

--- a/src/pages/projects/grafana-cloud-observability.astro
+++ b/src/pages/projects/grafana-cloud-observability.astro
@@ -37,7 +37,7 @@
 }
 
 body {
-  background: #2a2720;
+  background: #16304C;
   color: #ffffff;
   font-family: -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", sans-serif;
   line-height: 1.6;
@@ -51,7 +51,7 @@ body {
   left: 0;
   right: 0;
   padding: 24px 48px;
-  background: linear-gradient(to bottom, #2a2720 0%, transparent 100%);
+  background: linear-gradient(to bottom, #16304C 0%, transparent 100%);
   z-index: 100;
   backdrop-filter: blur(10px);
   display: flex;
@@ -94,7 +94,7 @@ body {
   display: flex;
   flex-direction: column;
   justify-content: center;
-  background: #2a2720;
+  background: #16304C;
   position: relative;
 }
 
@@ -157,7 +157,7 @@ body {
 .hero-right {
   position: relative;
   overflow: hidden;
-  background: #161513;
+  background: #102237;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -222,7 +222,7 @@ body {
 }
 
 .problem-stats {
-  background: #211f19;
+  background: #182E49;
   padding: 48px;
   border-radius: 4px;
 }
@@ -252,7 +252,7 @@ body {
 /* Research Visual */
 .research-image-container {
   margin: 80px 0;
-  background: #161513;
+  background: #102237;
   padding: 40px;
   border-radius: 8px;
 }
@@ -292,7 +292,7 @@ body {
 }
 
 .insight-card {
-  background: #211f19;
+  background: #182E49;
   padding: 32px;
   border-left: 3px solid #ff5f00;
   margin-bottom: 24px;
@@ -321,7 +321,7 @@ body {
   height: 0;
   overflow: hidden;
   border-radius: 8px;
-  background: #161513;
+  background: #102237;
 }
 
 .video-container iframe {
@@ -350,7 +350,7 @@ body {
 }
 
 .solution-card {
-  background: #211f19;
+  background: #182E49;
   padding: 48px;
   border-radius: 4px;
   transition: transform 0.3s;
@@ -385,7 +385,7 @@ body {
   width: 100vw;
   margin-left: calc(-50vw + 50%);
   padding: 80px 0;
-  background: #161513;
+  background: #102237;
   margin-top: 120px;
   margin-bottom: 120px;
   display: flex;
@@ -446,7 +446,7 @@ body {
 }
 
 .impact-metrics {
-  background: #211f19;
+  background: #182E49;
   padding: 48px;
   border-radius: 4px;
   position: sticky;

--- a/src/pages/projects/grafana-cloud-onboarding.astro
+++ b/src/pages/projects/grafana-cloud-onboarding.astro
@@ -37,7 +37,7 @@
 }
 
 body {
-  background: #2a2720;
+  background: #16304C;
   color: #ffffff;
   font-family: -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", sans-serif;
   line-height: 1.6;
@@ -51,7 +51,7 @@ body {
   left: 0;
   right: 0;
   padding: 24px 48px;
-  background: linear-gradient(to bottom, #2a2720 0%, transparent 100%);
+  background: linear-gradient(to bottom, #16304C 0%, transparent 100%);
   z-index: 100;
   backdrop-filter: blur(10px);
   display: flex;
@@ -94,7 +94,7 @@ body {
   display: flex;
   flex-direction: column;
   justify-content: center;
-  background: #2a2720;
+  background: #16304C;
   position: relative;
 }
 
@@ -158,7 +158,7 @@ body {
 .hero-right {
   position: relative;
   overflow: hidden;
-  background: #161513;
+  background: #102237;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -219,7 +219,7 @@ body {
 }
 
 .problem-visual {
-  background: #161513;
+  background: #102237;
   border-radius: 8px;
   overflow: hidden;
   padding: 32px;
@@ -250,14 +250,14 @@ body {
 }
 
 .stat-item {
-  background: #2a2720;
+  background: #16304C;
   padding: 48px 32px;
   text-align: center;
   transition: background 0.3s;
 }
 
 .stat-item:hover {
-  background: #211f19;
+  background: #182E49;
 }
 
 .stat-value {
@@ -316,7 +316,7 @@ body {
   width: 100%;
   height: auto;
   border-radius: 8px;
-  background: #161513;
+  background: #102237;
 }
 
 /* Solution Showcase */
@@ -332,7 +332,7 @@ body {
 }
 
 .showcase-item {
-  background: #211f19;
+  background: #182E49;
   border-radius: 8px;
   overflow: hidden;
 }
@@ -357,7 +357,7 @@ body {
   height: 0;
   overflow: hidden;
   border-radius: 8px;
-  background: #161513;
+  background: #102237;
   margin: 48px 0;
 }
 
@@ -379,7 +379,7 @@ body {
 }
 
 .process-card {
-  background: #211f19;
+  background: #182E49;
   padding: 48px;
   border-radius: 4px;
   border-left: 3px solid #ff5f00;
@@ -407,7 +407,7 @@ body {
 
 /* Results Section */
 .results-section {
-  background: #211f19;
+  background: #182E49;
   padding: 80px;
   border-radius: 8px;
   margin: 120px 0;
@@ -461,7 +461,7 @@ body {
   width: 100vw;
   margin-left: calc(-50vw + 50%);
   padding: 120px 48px;
-  background: #161513;
+  background: #102237;
   margin-top: 120px;
   margin-bottom: 120px;
 }

--- a/src/pages/projects/grafana-frontend.astro
+++ b/src/pages/projects/grafana-frontend.astro
@@ -37,7 +37,7 @@
 }
 
 body {
-  background: #2a2720;
+  background: #16304C;
   color: #ffffff;
   font-family: -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", sans-serif;
   line-height: 1.6;
@@ -51,7 +51,7 @@ body {
   left: 0;
   right: 0;
   padding: 24px 48px;
-  background: linear-gradient(to bottom, #2a2720 0%, transparent 100%);
+  background: linear-gradient(to bottom, #16304C 0%, transparent 100%);
   z-index: 100;
   backdrop-filter: blur(10px);
   display: flex;
@@ -94,7 +94,7 @@ body {
   display: flex;
   flex-direction: column;
   justify-content: center;
-  background: #2a2720;
+  background: #16304C;
   position: relative;
 }
 
@@ -166,7 +166,7 @@ body {
 .hero-right {
   position: relative;
   overflow: hidden;
-  background: #161513;
+  background: #102237;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -250,7 +250,7 @@ body {
 }
 
 .challenge-stats {
-  background: #211f19;
+  background: #182E49;
   padding: 48px;
   border-radius: 4px;
 }
@@ -285,7 +285,7 @@ body {
 }
 
 .competitor-card {
-  background: #161513;
+  background: #102237;
   border-radius: 8px;
   overflow: hidden;
   transition: transform 0.3s;
@@ -305,7 +305,7 @@ body {
   padding: 24px;
   font-size: 14px;
   color: #888;
-  background: #161513;
+  background: #102237;
 }
 
 /* Process Section */
@@ -338,7 +338,7 @@ body {
 }
 
 .process-image {
-  background: #161513;
+  background: #102237;
   border-radius: 8px;
   overflow: hidden;
   position: relative;
@@ -371,7 +371,7 @@ body {
 
 .principle-card {
   padding: 48px;
-  background: #211f19;
+  background: #182E49;
   border-bottom: 3px solid #ff5f00;
   transition: transform 0.3s;
 }
@@ -398,7 +398,7 @@ body {
   width: 100vw;
   margin-left: calc(-50vw + 50%);
   padding: 80px 48px;
-  background: #161513;
+  background: #102237;
   margin-top: 120px;
   margin-bottom: 120px;
   text-align: center;
@@ -428,7 +428,7 @@ body {
 }
 
 .video-item {
-  background: #211f19;
+  background: #182E49;
   border-radius: 8px;
   overflow: hidden;
   padding: 48px;
@@ -457,7 +457,7 @@ body {
   height: 0;
   overflow: hidden;
   border-radius: 4px;
-  background: #161513;
+  background: #102237;
 }
 
 .video-container iframe {
@@ -473,7 +473,7 @@ body {
 .quote-section {
   padding: 120px 80px;
   text-align: center;
-  background: linear-gradient(135deg, #211f19 0%, #161513 100%);
+  background: linear-gradient(135deg, #182E49 0%, #102237 100%);
   border-radius: 8px;
   margin: 120px 0;
 }
@@ -528,7 +528,7 @@ body {
 }
 
 .impact-sidebar {
-  background: #211f19;
+  background: #182E49;
   padding: 48px;
   border-radius: 4px;
   position: sticky;

--- a/src/pages/projects/grafana/index.astro
+++ b/src/pages/projects/grafana/index.astro
@@ -37,7 +37,7 @@
 }
 
 body {
-  background: #2a2720;
+  background: #16304C;
   color: #ffffff;
   font-family: -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", sans-serif;
   line-height: 1.6;
@@ -51,7 +51,7 @@ body {
   left: 0;
   right: 0;
   padding: 24px 48px;
-  background: linear-gradient(to bottom, #2a2720 0%, transparent 100%);
+  background: linear-gradient(to bottom, #16304C 0%, transparent 100%);
   z-index: 100;
   backdrop-filter: blur(10px);
   display: flex;
@@ -163,7 +163,7 @@ body {
 }
 
 .project-card {
-  background: linear-gradient(135deg, #211f19 0%, #161513 100%);
+  background: linear-gradient(135deg, #182E49 0%, #102237 100%);
   border: 1px solid rgba(255, 255, 255, 0.05);
   border-radius: 8px;
   overflow: hidden;
@@ -179,7 +179,7 @@ body {
 .project-image {
   width: 100%;
   height: 300px;
-  background: #161513;
+  background: #102237;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/pages/projects/keystrok.astro
+++ b/src/pages/projects/keystrok.astro
@@ -37,7 +37,7 @@
 }
 
 body {
-  background: #2a2720;
+  background: #16304C;
   color: #ffffff;
   font-family: -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", sans-serif;
   line-height: 1.6;
@@ -51,7 +51,7 @@ body {
   left: 0;
   right: 0;
   padding: 24px 48px;
-  background: linear-gradient(to bottom, #2a2720 0%, transparent 100%);
+  background: linear-gradient(to bottom, #16304C 0%, transparent 100%);
   z-index: 100;
   backdrop-filter: blur(10px);
   display: flex;
@@ -94,7 +94,7 @@ body {
   display: flex;
   flex-direction: column;
   justify-content: center;
-  background: #2a2720;
+  background: #16304C;
   position: relative;
 }
 
@@ -175,7 +175,7 @@ body {
 .hero-right {
   position: relative;
   overflow: hidden;
-  background: #161513;
+  background: #102237;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -263,7 +263,7 @@ body {
 }
 
 .problem-sidebar {
-  background: #211f19;
+  background: #182E49;
   padding: 48px;
   border-radius: 4px;
 }
@@ -313,14 +313,14 @@ body {
 }
 
 .stat-card {
-  background: #2a2720;
+  background: #16304C;
   padding: 48px 32px;
   text-align: center;
   transition: background 0.3s;
 }
 
 .stat-card:hover {
-  background: #211f19;
+  background: #182E49;
 }
 
 .stat-value {
@@ -346,7 +346,7 @@ body {
 
 .segment-card {
   padding: 48px;
-  background: #211f19;
+  background: #182E49;
   border-left: 3px solid #18a0fb;
   transition: transform 0.3s;
 }
@@ -411,7 +411,7 @@ body {
 }
 
 .design-decisions {
-  background: #211f19;
+  background: #182E49;
   padding: 48px;
   border-radius: 4px;
 }
@@ -481,7 +481,7 @@ body {
 }
 
 .gallery-item {
-  background: #161513;
+  background: #102237;
   border-radius: 8px;
   overflow: hidden;
   transition: transform 0.3s;
@@ -499,7 +499,7 @@ body {
 
 .gallery-caption {
   padding: 24px;
-  background: #161513;
+  background: #102237;
   font-size: 14px;
   color: #888;
 }
@@ -508,7 +508,7 @@ body {
 .quote-section {
   padding: 120px 80px;
   text-align: center;
-  background: #211f19;
+  background: #182E49;
   border-radius: 8px;
   margin: 120px 0;
   position: relative;
@@ -565,7 +565,7 @@ body {
 }
 
 .results-impact {
-  background: #211f19;
+  background: #182E49;
   padding: 48px;
   border-radius: 4px;
 }

--- a/src/pages/projects/service-radar-part1.astro
+++ b/src/pages/projects/service-radar-part1.astro
@@ -37,7 +37,7 @@
 }
 
 body {
-  background: #2a2720;
+  background: #16304C;
   color: #ffffff;
   font-family: -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", sans-serif;
   line-height: 1.6;
@@ -51,7 +51,7 @@ body {
   left: 0;
   right: 0;
   padding: 24px 48px;
-  background: linear-gradient(to bottom, #2a2720 0%, transparent 100%);
+  background: linear-gradient(to bottom, #16304C 0%, transparent 100%);
   z-index: 100;
   backdrop-filter: blur(10px);
   display: flex;
@@ -94,7 +94,7 @@ body {
   display: flex;
   flex-direction: column;
   justify-content: center;
-  background: #2a2720;
+  background: #16304C;
   position: relative;
 }
 
@@ -165,7 +165,7 @@ body {
 .hero-right {
   position: relative;
   overflow: hidden;
-  background: #161513;
+  background: #102237;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -229,7 +229,7 @@ body {
 }
 
 .highlight-box {
-  background: #211f19;
+  background: #182E49;
   padding: 48px;
   border-left: 3px solid #00a8ff;
   border-radius: 4px;
@@ -258,7 +258,7 @@ body {
 }
 
 .discovery-image {
-  background: #161513;
+  background: #102237;
   border-radius: 8px;
   overflow: hidden;
   transition: transform 0.3s;
@@ -278,7 +278,7 @@ body {
   padding: 24px;
   font-size: 14px;
   color: #888;
-  background: #161513;
+  background: #102237;
 }
 
 /* Process Section */
@@ -317,7 +317,7 @@ body {
   height: 20px;
   background: #00a8ff;
   border-radius: 50%;
-  border: 4px solid #2a2720;
+  border: 4px solid #16304C;
 }
 
 .timeline-title {
@@ -339,7 +339,7 @@ body {
 }
 
 .sketch-container {
-  background: #161513;
+  background: #102237;
   padding: 48px;
   border-radius: 8px;
   margin-bottom: 48px;
@@ -359,7 +359,7 @@ body {
 }
 
 .exploration-item {
-  background: #211f19;
+  background: #182E49;
   border-radius: 8px;
   overflow: hidden;
   transition: transform 0.3s;
@@ -383,7 +383,7 @@ body {
 
 /* Accessibility Focus */
 .accessibility-section {
-  background: #211f19;
+  background: #182E49;
   padding: 80px;
   border-radius: 8px;
   margin: 120px 0;
@@ -453,7 +453,7 @@ body {
 }
 
 .results-visual {
-  background: #161513;
+  background: #102237;
   border-radius: 8px;
   overflow: hidden;
 }
@@ -469,7 +469,7 @@ body {
   width: 100vw;
   margin-left: calc(-50vw + 50%);
   padding: 80px 48px;
-  background: #161513;
+  background: #102237;
   margin-top: 120px;
   margin-bottom: 120px;
 }
@@ -495,7 +495,7 @@ body {
 
 /* Key Questions */
 .questions-list {
-  background: #211f19;
+  background: #182E49;
   padding: 48px;
   border-radius: 8px;
   margin: 48px 0;

--- a/src/pages/projects/service-radar-part2.astro
+++ b/src/pages/projects/service-radar-part2.astro
@@ -37,7 +37,7 @@
 }
 
 body {
-  background: #2a2720;
+  background: #16304C;
   color: #ffffff;
   font-family: -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", sans-serif;
   line-height: 1.6;
@@ -51,7 +51,7 @@ body {
   left: 0;
   right: 0;
   padding: 24px 48px;
-  background: linear-gradient(to bottom, #2a2720 0%, transparent 100%);
+  background: linear-gradient(to bottom, #16304C 0%, transparent 100%);
   z-index: 100;
   backdrop-filter: blur(10px);
   display: flex;
@@ -94,7 +94,7 @@ body {
   display: flex;
   flex-direction: column;
   justify-content: center;
-  background: #2a2720;
+  background: #16304C;
   position: relative;
 }
 
@@ -165,7 +165,7 @@ body {
 .hero-right {
   position: relative;
   overflow: hidden;
-  background: #161513;
+  background: #102237;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -211,7 +211,7 @@ body {
 
 /* Research Questions */
 .questions-section {
-  background: #211f19;
+  background: #182E49;
   padding: 80px;
   border-radius: 8px;
   margin: 80px 0;
@@ -298,7 +298,7 @@ body {
 }
 
 .phase-content {
-  background: #211f19;
+  background: #182E49;
   padding: 48px;
   border-radius: 8px;
 }
@@ -351,7 +351,7 @@ body {
 }
 
 .sketch-item {
-  background: #161513;
+  background: #102237;
   border-radius: 8px;
   overflow: hidden;
   transition: transform 0.3s;
@@ -382,7 +382,7 @@ body {
 }
 
 .wireframe-item {
-  background: #211f19;
+  background: #182E49;
   border-radius: 8px;
   overflow: hidden;
   transition: transform 0.3s;
@@ -406,7 +406,7 @@ body {
 
 /* Considerations List */
 .considerations-section {
-  background: linear-gradient(135deg, #211f19 0%, #161513 100%);
+  background: linear-gradient(135deg, #182E49 0%, #102237 100%);
   padding: 80px;
   border-radius: 8px;
   margin: 120px 0;
@@ -462,7 +462,7 @@ body {
 }
 
 .style-item {
-  background: #211f19;
+  background: #182E49;
   padding: 32px;
   border-radius: 8px;
   text-align: center;
@@ -520,7 +520,7 @@ body {
   padding: 80px;
   margin: 120px 0;
   text-align: center;
-  background: #211f19;
+  background: #182E49;
   border-radius: 8px;
 }
 

--- a/src/pages/projects/service-radar/index.astro
+++ b/src/pages/projects/service-radar/index.astro
@@ -37,7 +37,7 @@
 }
 
 body {
-  background: #2a2720;
+  background: #16304C;
   color: #ffffff;
   font-family: -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", sans-serif;
   line-height: 1.6;
@@ -51,7 +51,7 @@ body {
   left: 0;
   right: 0;
   padding: 24px 48px;
-  background: linear-gradient(to bottom, #2a2720 0%, transparent 100%);
+  background: linear-gradient(to bottom, #16304C 0%, transparent 100%);
   z-index: 100;
   backdrop-filter: blur(10px);
   display: flex;
@@ -163,7 +163,7 @@ body {
 }
 
 .project-card {
-  background: linear-gradient(135deg, #211f19 0%, #161513 100%);
+  background: linear-gradient(135deg, #182E49 0%, #102237 100%);
   border: 1px solid rgba(255, 255, 255, 0.05);
   border-radius: 8px;
   overflow: hidden;
@@ -179,7 +179,7 @@ body {
 .project-image {
   width: 100%;
   height: 300px;
-  background: #161513;
+  background: #102237;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -269,7 +269,7 @@ body {
 
 /* Info Section */
 .info-section {
-  background: #211f19;
+  background: #182E49;
   padding: 80px;
   border-radius: 8px;
   margin: 120px 0;

--- a/src/pages/unlock.astro
+++ b/src/pages/unlock.astro
@@ -17,7 +17,7 @@ const hasError = Astro.url.searchParams.has('error');
 
     body {
       /* !important to override global.css's desktop body bg lock */
-      background: #161513 !important;
+      background: #102237 !important;
       color: #ffffff;
       font-family: 'NB International', -apple-system, BlinkMacSystemFont, 'SF Pro Display', 'Inter', sans-serif;
       min-height: 100vh;
@@ -64,8 +64,8 @@ const hasError = Astro.url.searchParams.has('error');
     .password-input {
       width: 100%;
       padding: 14px 16px;
-      background: #211f19;
-      border: 1px solid #34312a;
+      background: #182E49;
+      border: 1px solid #2C476A;
       border-radius: 8px;
       color: #ffffff;
       font-family: inherit;
@@ -90,7 +90,7 @@ const hasError = Astro.url.searchParams.has('error');
       width: 100%;
       padding: 14px 16px;
       background: #ffffff;
-      color: #161513;
+      color: #102237;
       border: none;
       border-radius: 8px;
       font-family: inherit;


### PR DESCRIPTION
## Summary
Rebuilds the homepage as the **"Peel"** direction and harmonizes the rest of the site onto the dark-blue palette.

- **Home (`index.astro`)** — editorial cover that peels back via a page-curl/dog-ear into the About-as-Figma-canvas workspace. Cover "Selected work" binds to `lib/work.ts`, Notes "latest" to the notes collection; footer + Dynatrace link wired to real contacts. Fold/pan ported to a plain inline-script rAF loop (no React).
- **Palette** — notes, case studies, and `/unlock` shifted from the warm-dark canvas to the index's dark blue: base `#102237`, cards `#182E49`, chrome `#16304C`. Accents/text untouched.

## Notes
- Earlier commits on this branch include the prior "Command" direction; this PR supersedes the home with the Peel direction.
- `astro check` passes (0 errors). All routes return 200 locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)